### PR TITLE
Fix/bugbot security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,15 @@ This release addresses critical security issues identified by Cursor Bugbot code
 
 #### Rust Smart Contract
 - **Balance comparison logic bug** - `verify_balance_proof` now uses proper numeric comparison via `parse_decimal_to_scaled()` instead of incorrect byte length comparison (`balance_data.len() >= required_amount_data.len()`)
+- **Malformed input vulnerability** - `parse_decimal_to_scaled()` now returns `None` for malformed inputs like "-", ".", or empty bytes instead of `Some(0)`, preventing invalid balance data from being treated as zero
 - **Test algorithm mismatch** - All tests now use `compute_test_hmac()` with proper HMAC-SHA256 (RFC 2104 with ipad/opad) instead of plain SHA256, matching production contract behavior
 
 ### Added
 - `SorobanHelper.MaxBytesLength` constant (255) for explicit length limit documentation
-- `parse_decimal_to_scaled()` function in Rust contract for accurate decimal number parsing
+- `parse_decimal_to_scaled()` function in Rust contract for accurate decimal number parsing with `has_digits` validation
 - `compute_test_hmac()` helper in Rust tests for consistent HMAC computation
 - `test_verify_balance_proof_insufficient()` test case for balance < required scenario
+- `test_verify_balance_proof_malformed_input()` test case for malformed inputs like "-", "."
 
 ### Changed
 - Balance verification now correctly handles edge cases like "99.0" vs "100.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## [1.3.2] - 2025-12-03
+
+### Security Fixes (Bugbot Review)
+
+This release addresses critical security issues identified by Cursor Bugbot code review.
+
+### Fixed
+
+#### C# Library
+- **SorobanHelper: Data truncation vulnerability** - `EncodeBytesAsScVal` and `EncodeStringAsScVal` now validate input length and throw `ArgumentException` for data exceeding 255 bytes, preventing silent data corruption
+- **SorobanRpcClient: XDR boolean decode false positives** - Replaced unsafe `xdrBytes.Any(b => b == 0x01)` heuristic with proper SCVal format parsing using type discriminant validation
+
+#### Rust Smart Contract
+- **Balance comparison logic bug** - `verify_balance_proof` now uses proper numeric comparison via `parse_decimal_to_scaled()` instead of incorrect byte length comparison (`balance_data.len() >= required_amount_data.len()`)
+- **Test algorithm mismatch** - All tests now use `compute_test_hmac()` with proper HMAC-SHA256 (RFC 2104 with ipad/opad) instead of plain SHA256, matching production contract behavior
+
+### Added
+- `SorobanHelper.MaxBytesLength` constant (255) for explicit length limit documentation
+- `parse_decimal_to_scaled()` function in Rust contract for accurate decimal number parsing
+- `compute_test_hmac()` helper in Rust tests for consistent HMAC computation
+- `test_verify_balance_proof_insufficient()` test case for balance < required scenario
+
+### Changed
+- Balance verification now correctly handles edge cases like "99.0" vs "100.0"
+- XDR boolean decoding now validates SCValType discriminant before extracting value
+
+---
+
+## [1.3.1] - 2025-12-03
+
+### Fixed
+- Added `SorobanHelper` class with SCVal encoding/decoding utilities
+- Fixed balance parsing with `CultureInfo.InvariantCulture` for consistent decimal handling
+- Added `using StellarDotnetSdk.Accounts` for `KeyPair` class access in tests
+- Improved test coverage for Stellar integration
+
+---
+
 ## [1.3.0] - 2025-12-02
 
 ### Major Release: Production-Ready Stellar Integration

--- a/ZkpSharp/Integration/Stellar/SorobanHelper.cs
+++ b/ZkpSharp/Integration/Stellar/SorobanHelper.cs
@@ -13,11 +13,25 @@ namespace ZkpSharp.Integration.Stellar
         /// </summary>
         /// <param name="bytes">The bytes to encode.</param>
         /// <returns>Base64-encoded SCVal representation.</returns>
+        /// <summary>
+        /// Maximum length for byte data in simplified SCVal encoding.
+        /// For larger data, use proper XDR encoding with Stellar SDK.
+        /// </summary>
+        public const int MaxBytesLength = 255;
+
         public static string EncodeBytesAsScVal(byte[] bytes)
         {
             if (bytes == null || bytes.Length == 0)
             {
                 throw new ArgumentException("Bytes cannot be null or empty.", nameof(bytes));
+            }
+
+            if (bytes.Length > MaxBytesLength)
+            {
+                throw new ArgumentException(
+                    $"Bytes length ({bytes.Length}) exceeds maximum allowed ({MaxBytesLength}). " +
+                    "For larger data, use proper XDR encoding with Stellar SDK.",
+                    nameof(bytes));
             }
 
             // For SCVal bytes type, we prepend a type indicator and encode
@@ -72,6 +86,14 @@ namespace ZkpSharp.Integration.Stellar
             }
 
             var bytes = Encoding.UTF8.GetBytes(value);
+
+            if (bytes.Length > MaxBytesLength)
+            {
+                throw new ArgumentException(
+                    $"String byte length ({bytes.Length}) exceeds maximum allowed ({MaxBytesLength}). " +
+                    "For larger strings, use proper XDR encoding with Stellar SDK.",
+                    nameof(value));
+            }
 
             // Type 14 (0x0E) is also used for strings in Soroban (as bytes)
             var scVal = new byte[bytes.Length + 4];

--- a/ZkpSharp/ZkpSharp.csproj
+++ b/ZkpSharp/ZkpSharp.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <PackageVersion>1.3.1</PackageVersion>
+    <PackageVersion>1.3.2</PackageVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/asagynbaev</PackageProjectUrl>
     <RepositoryUrl>https://github.com/asagynbaev/ZkpSharp</RepositoryUrl>
@@ -13,7 +13,7 @@
     <Authors>Azimbek Sagynbaev</Authors>
     <Description>.NET library for implementing Zero-Knowledge Proofs (ZKP) with production-ready Stellar Soroban integration. Supports age, balance, membership, range, and time condition proofs with on-chain verification.</Description>
     <PackageTags>zkp;zero-knowledge-proof;cryptography;privacy;blockchain;stellar;soroban;smart-contracts;ton;solana;hmac</PackageTags>
-    <PackageReleaseNotes>v1.3.1: Bug fixes - added SorobanHelper class, fixed balance parsing with InvariantCulture, improved test coverage.</PackageReleaseNotes>
+    <PackageReleaseNotes>v1.3.2: Security fixes - SorobanHelper validates max 255 bytes to prevent truncation, XDR boolean decode uses proper SCVal format instead of heuristic, Rust contract uses numeric comparison for balance verification, tests use HMAC-SHA256 matching production.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/contracts/stellar/contracts/proof-balance/src/test.rs
+++ b/contracts/stellar/contracts/proof-balance/src/test.rs
@@ -24,18 +24,50 @@ mod test {
         salt
     }
 
-    /// Helper to manually compute HMAC for testing
-    fn compute_expected_hmac(env: &Env, data: &Bytes, salt: &Bytes, key: &BytesN<32>) -> BytesN<32> {
-        let contract = ZkpVerifierClient::new(env, &env.register_contract(None, ZkpVerifier));
+    /// Computes HMAC-SHA256 for testing - matches the contract's compute_hmac implementation.
+    /// This is the same algorithm used in the contract to ensure tests match production behavior.
+    fn compute_test_hmac(env: &Env, message: &Bytes, key: &BytesN<32>) -> BytesN<32> {
+        const IPAD: u8 = 0x36;
+        const OPAD: u8 = 0x5c;
+        const BLOCK_SIZE: u32 = 64;
+
+        // Create padded key (64 bytes)
+        let mut key_padded = Bytes::new(env);
+        for i in 0..32 {
+            key_padded.push_back(key.get(i).unwrap());
+        }
+        for _ in 32..BLOCK_SIZE {
+            key_padded.push_back(0);
+        }
+
+        // Compute inner hash: H((K ⊕ ipad) || m)
+        let mut inner_data = Bytes::new(env);
+        for i in 0..BLOCK_SIZE {
+            inner_data.push_back(key_padded.get(i).unwrap() ^ IPAD);
+        }
+        inner_data.append(message);
         
-        // Concatenate data and salt
+        let inner_hash = env.crypto().sha256(&inner_data);
+
+        // Compute outer hash: H((K ⊕ opad) || inner_hash)
+        let mut outer_data = Bytes::new(env);
+        for i in 0..BLOCK_SIZE {
+            outer_data.push_back(key_padded.get(i).unwrap() ^ OPAD);
+        }
+        outer_data.append(&inner_hash.to_bytes());
+
+        env.crypto().sha256(&outer_data)
+    }
+
+    /// Helper to compute expected HMAC proof for test data
+    fn compute_expected_proof(env: &Env, data: &Bytes, salt: &Bytes, key: &BytesN<32>) -> BytesN<32> {
+        // Concatenate data and salt (same as contract does)
         let mut message = Bytes::new(env);
         message.append(data);
         message.append(salt);
         
-        // For testing, we'll use the contract's internal HMAC computation
-        // In real scenario, this would match the C# library's HMAC output
-        env.crypto().sha256(&message) // Simplified for testing
+        // Compute HMAC-SHA256 (matching contract's algorithm)
+        compute_test_hmac(env, &message, key)
     }
 
     #[test]
@@ -53,14 +85,8 @@ mod test {
         let mut data = Bytes::new(&env);
         data.extend_from_array(&[1, 2, 3, 4, 5]);
 
-        // Concatenate data and salt for HMAC
-        let mut message = Bytes::new(&env);
-        message.append(&data);
-        message.append(&salt);
-
-        // For this test, we compute the expected proof using the same logic
-        // In production, this would come from the C# library
-        let proof = env.crypto().sha256(&message);
+        // Compute proof using HMAC-SHA256 (same algorithm as contract)
+        let proof = compute_expected_proof(&env, &data, &salt, &key);
 
         // Verify the proof
         let result = client.verify_proof(&proof, &data, &salt, &key);
@@ -138,11 +164,8 @@ mod test {
         let mut required_data = Bytes::new(&env);
         required_data.extend_from_array(b"500.0");
 
-        // Compute proof for the balance
-        let mut message = Bytes::new(&env);
-        message.append(&balance_data);
-        message.append(&salt);
-        let proof = env.crypto().sha256(&message);
+        // Compute proof using HMAC-SHA256
+        let proof = compute_expected_proof(&env, &balance_data, &salt, &key);
 
         // Verify balance proof
         let result = client.verify_balance_proof(
@@ -154,6 +177,40 @@ mod test {
         );
 
         assert!(result, "Valid balance proof should be verified");
+    }
+
+    #[test]
+    fn test_verify_balance_proof_insufficient() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register_contract(None, ZkpVerifier);
+        let client = ZkpVerifierClient::new(&env, &contract_id);
+
+        let key = create_test_key(&env);
+        let salt = create_test_salt(&env);
+        
+        // Balance data - smaller than required
+        let mut balance_data = Bytes::new(&env);
+        balance_data.extend_from_array(b"99.0");
+
+        // Required amount - larger than balance
+        let mut required_data = Bytes::new(&env);
+        required_data.extend_from_array(b"100.0");
+
+        // Compute valid proof for the balance
+        let proof = compute_expected_proof(&env, &balance_data, &salt, &key);
+
+        // Verify balance proof - should fail because balance < required
+        let result = client.verify_balance_proof(
+            &proof,
+            &balance_data,
+            &required_data,
+            &salt,
+            &key,
+        );
+
+        assert!(!result, "Balance proof should fail when balance < required");
     }
 
     #[test]
@@ -177,10 +234,8 @@ mod test {
             let mut data = Bytes::new(&env);
             data.extend_from_array(&[i, i + 1, i + 2]);
 
-            let mut message = Bytes::new(&env);
-            message.append(&data);
-            message.append(&salt);
-            let proof = env.crypto().sha256(&message);
+            // Compute proof using HMAC-SHA256
+            let proof = compute_expected_proof(&env, &data, &salt, &key);
 
             proofs.push_back(proof);
             data_items.push_back(data);
@@ -207,20 +262,17 @@ mod test {
         let mut data_items = Vec::new(&env);
         let mut salts = Vec::new(&env);
 
-        // First proof - valid
+        // First proof - valid (using HMAC-SHA256)
         let salt1 = create_test_salt(&env);
         let mut data1 = Bytes::new(&env);
         data1.extend_from_array(&[1, 2, 3]);
-        let mut message1 = Bytes::new(&env);
-        message1.append(&data1);
-        message1.append(&salt1);
-        let proof1 = env.crypto().sha256(&message1);
+        let proof1 = compute_expected_proof(&env, &data1, &salt1, &key);
 
         proofs.push_back(proof1);
         data_items.push_back(data1);
         salts.push_back(salt1);
 
-        // Second proof - INVALID
+        // Second proof - INVALID (wrong hash, all zeros)
         let salt2 = create_test_salt(&env);
         let mut data2 = Bytes::new(&env);
         data2.extend_from_array(&[4, 5, 6]);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Harden SCVal encoding/decoding and Rust balance verification, add decimal parsing, and update tests to HMAC-SHA256 with new negative cases.
> 
> - **C# (Stellar Integration)**
>   - `ZkpSharp/Integration/Stellar/SorobanHelper.cs`: add `MaxBytesLength` (255) and enforce length checks in `EncodeBytesAsScVal`/`EncodeStringAsScVal` to prevent truncation.
>   - `ZkpSharp/Integration/Stellar/SorobanRpcClient.cs`: replace heuristic XDR bool parsing with SCVal discriminant validation and value extraction.
> - **Rust Contract (`contracts/stellar/contracts/proof-balance`)**
>   - `src/lib.rs`:
>     - `verify_balance_proof` now parses decimals and compares numerically instead of byte-length.
>     - Add `parse_decimal_to_scaled()` returning `None` on malformed inputs and scaling to 1e8.
>   - Improved eventing on invalid input.
> - **Tests**
>   - `src/test.rs`:
>     - Introduce `compute_test_hmac()` and use it to generate proofs (HMAC-SHA256 with ipad/opad).
>     - Add cases: `test_verify_balance_proof_insufficient` and `test_verify_balance_proof_malformed_input`.
> - **Versioning/Docs**
>   - Bump package to `1.3.2`; update `CHANGELOG.md` and release notes to reflect security fixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a933484ad91550ca4f1c6416857997c8b1734de7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->