### PR TITLE
chore: update dependencies to fix Dependabot security alerts

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up .NET SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ This release addresses critical security issues identified by Cursor Bugbot code
 - Balance verification now correctly handles edge cases like "99.0" vs "100.0"
 - XDR boolean decoding now validates SCValType discriminant before extracting value
 
+### Dependencies Updated
+- `stellar-dotnet-sdk`: 13.0.0 → 14.0.1
+- `stellar-dotnet-sdk-xdr`: 13.0.0 → 14.0.1
+- `coverlet.collector`: 6.0.0 → 6.0.4
+- `Microsoft.NET.Test.Sdk`: 17.8.0 → 17.12.0
+- `xunit`: 2.9.2 → 2.9.3
+- `xunit.runner.visualstudio`: 2.5.3 → 3.0.2
+- GitHub Actions: `actions/checkout@v2` → `v4`, `actions/setup-dotnet@v1` → `v4`
+
 ---
 
 ## [1.3.1] - 2025-12-03

--- a/ZkpSharp.Tests/ZkpSharp.Tests.csproj
+++ b/ZkpSharp.Tests/ZkpSharp.Tests.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ZkpSharp/ZkpSharp.csproj
+++ b/ZkpSharp/ZkpSharp.csproj
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="stellar-dotnet-sdk" Version="13.0.0" />
-    <PackageReference Include="stellar-dotnet-sdk-xdr" Version="13.0.0" />
+    <PackageReference Include="stellar-dotnet-sdk" Version="14.0.1" />
+    <PackageReference Include="stellar-dotnet-sdk-xdr" Version="14.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- GitHub Actions: checkout@v2  v4, setup-dotnet@v1  v4
- stellar-dotnet-sdk: 13.0.0  14.0.1
- stellar-dotnet-sdk-xdr: 13.0.0  14.0.1
- coverlet.collector: 6.0.0  6.0.4
- Microsoft.NET.Test.Sdk: 17.8.0  17.12.0
- xunit: 2.9.2  2.9.3
- xunit.runner.visualstudio: 2.5.3  3.0.2