### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/asagynbaev/ZkpSharp/security/code-scanning/1](https://github.com/asagynbaev/ZkpSharp/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions` block that narrows `GITHUB_TOKEN` to the least privileges needed. For this workflow, the job only needs to read repository contents to check out code and run `dotnet` commands, so `contents: read` at minimum is sufficient. Adding this block either at the workflow root (to apply to all jobs) or under the `build` job (to apply only to that job) resolves the issue.

The single best change here, without affecting functionality, is to add a root-level `permissions` block after the `on:` section, before `jobs:`. This ensures all current and future jobs in this workflow are restricted to read-only repository contents by default. Concretely, in `.github/workflows/dotnet.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing trigger configuration (`on: ...`) and the `jobs:` key. No imports or additional definitions are required since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 06fdf88c3f3ca6708e939e450347f7c367065608. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->