### PR TITLE
ci(evm): run EVM anchor smoke tests live against a local Hardhat node

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -83,6 +83,64 @@ jobs:
           npm run export-abi
           git diff --exit-code abi/
 
+  evm-smoke:
+    # Live on-chain integration: runs the EvmChainAnchor / EvmAllowlistGateway smoke tests
+    # against a local Hardhat node. These tests are [SkippableFact]-gated on the TESSERA_EVM_*
+    # env vars, so without this job they silently skip — here we give them a real chain.
+    runs-on: ubuntu-latest
+    env:
+      TESSERA_EVM_RPC: http://127.0.0.1:8545
+      TESSERA_EVM_CHAINID: '31337'
+      # Stock Hardhat account #0 — publicly known, throwaway, only valid on a local node.
+      TESSERA_EVM_KEY: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0'
+
+      - name: Install EVM dependencies
+        working-directory: chains/evm
+        run: npm ci
+
+      - name: Compile contracts
+        working-directory: chains/evm
+        run: npx hardhat compile
+
+      - name: Start local Hardhat node
+        working-directory: chains/evm
+        run: |
+          npx hardhat node > hardhat-node.log 2>&1 &
+          for i in $(seq 1 30); do
+            if curl -s -X POST http://127.0.0.1:8545 -H 'Content-Type: application/json' \
+                 --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' | grep -q result; then
+              echo "node up"; exit 0
+            fi
+            sleep 1
+          done
+          echo "Hardhat node failed to start:"; cat hardhat-node.log; exit 1
+
+      - name: Deploy IdentityRegistry + Allowlist
+        working-directory: chains/evm
+        run: npx hardhat run scripts/deploy-local.js --network localhost
+
+      - name: Export deployed addresses
+        working-directory: chains/evm
+        run: |
+          node -e "const d=require('./deployed.local.json');const fs=require('fs');fs.appendFileSync(process.env.GITHUB_ENV,'TESSERA_EVM_REGISTRY='+d.registry+'\n'+'TESSERA_EVM_ALLOWLIST='+d.allowlist+'\n')"
+
+      - name: Run EVM smoke tests (live against local node)
+        run: dotnet test src/Tessera.Chains.Evm.Tests --configuration Release --verbosity normal
+
   cardano-contract:
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -116,30 +116,32 @@ jobs:
         working-directory: chains/evm
         run: npx hardhat compile
 
-      - name: Start local Hardhat node
+      # Node start + deploy + test live in ONE step: a process backgrounded in an earlier step
+      # is not guaranteed to survive into later steps (the runner tears down a step's process
+      # tree at step end), which kills the local node before the tests can reach it.
+      - name: Run EVM smoke tests (live against local node)
         working-directory: chains/evm
         run: |
           npx hardhat node > hardhat-node.log 2>&1 &
+          NODE_PID=$!
+          trap "kill $NODE_PID 2>/dev/null || true" EXIT
+
+          up=
           for i in $(seq 1 30); do
             if curl -s -X POST http://127.0.0.1:8545 -H 'Content-Type: application/json' \
                  --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}' | grep -q result; then
-              echo "node up"; exit 0
+              up=1; echo "node up after ${i}s"; break
             fi
             sleep 1
           done
-          echo "Hardhat node failed to start:"; cat hardhat-node.log; exit 1
+          if [ -z "$up" ]; then echo "Hardhat node failed to start:"; cat hardhat-node.log; exit 1; fi
 
-      - name: Deploy IdentityRegistry + Allowlist
-        working-directory: chains/evm
-        run: npx hardhat run scripts/deploy-local.js --network localhost
+          npx hardhat run scripts/deploy-local.js --network localhost
+          export TESSERA_EVM_REGISTRY=$(node -e "process.stdout.write(require('./deployed.local.json').registry)")
+          export TESSERA_EVM_ALLOWLIST=$(node -e "process.stdout.write(require('./deployed.local.json').allowlist)")
+          echo "registry=$TESSERA_EVM_REGISTRY allowlist=$TESSERA_EVM_ALLOWLIST"
 
-      - name: Export deployed addresses
-        working-directory: chains/evm
-        run: |
-          node -e "const d=require('./deployed.local.json');const fs=require('fs');fs.appendFileSync(process.env.GITHUB_ENV,'TESSERA_EVM_REGISTRY='+d.registry+'\n'+'TESSERA_EVM_ALLOWLIST='+d.allowlist+'\n')"
-
-      - name: Run EVM smoke tests (live against local node)
-        run: dotnet test src/Tessera.Chains.Evm.Tests --configuration Release --verbosity normal
+          dotnet test ../../src/Tessera.Chains.Evm.Tests --configuration Release --verbosity normal
 
   cardano-contract:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ wwwroot/
 # Local environment files
 .env
 .env.local
+
+# Local EVM deploy artifact (addresses from scripts/deploy-local.js)
+deployed.local.json

--- a/chains/evm/.env.local.example
+++ b/chains/evm/.env.local.example
@@ -1,0 +1,24 @@
+# Local EVM smoke-test environment (template).
+#
+# Copy to .env.local and source it before running the EVM smoke tests against a
+# local Hardhat node:
+#
+#   cd chains/evm
+#   npx hardhat node &                                  # terminal A: local chain
+#   npx hardhat run scripts/deploy-local.js --network localhost   # deploy both contracts
+#   set -a; . ./.env.local; set +a                      # load these vars
+#   dotnet test ../../src/Tessera.Chains.Evm.Tests -c Release
+#
+# The values below are the stock Hardhat node defaults: chainId 31337 and the
+# well-known, publicly-known account #0. They are THROWAWAY — only ever valid on a
+# local node. NEVER put a real funded key here; .env.local is gitignored for that reason.
+#
+# REGISTRY/ALLOWLIST below are the deterministic first-two-deploy addresses Hardhat
+# produces from a fresh node. If you redeploy after other txs, read the actual values
+# from chains/evm/deployed.local.json (written by deploy-local.js) instead.
+
+TESSERA_EVM_RPC=http://127.0.0.1:8545
+TESSERA_EVM_CHAINID=31337
+TESSERA_EVM_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+TESSERA_EVM_REGISTRY=0x5FbDB2315678afecb367f032d93F642f64180aa3
+TESSERA_EVM_ALLOWLIST=0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512

--- a/chains/evm/scripts/deploy-local.js
+++ b/chains/evm/scripts/deploy-local.js
@@ -1,0 +1,44 @@
+// Deploys IdentityRegistry + Allowlist to a local node (e.g. `npx hardhat node`) and writes
+// their addresses to deployed.local.json so the C# EVM smoke tests can pick them up.
+//
+// The deployer becomes the IdentityRegistry authority and the Allowlist owner/agent, which is
+// exactly what the smoke tests need (same signing key flips the allowlist).
+//
+// Usage: npx hardhat run scripts/deploy-local.js --network localhost
+const { ethers } = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  console.log(`Deployer: ${deployer.address}`);
+
+  const Registry = await ethers.getContractFactory("IdentityRegistry");
+  const registry = await Registry.deploy(deployer.address);
+  await registry.waitForDeployment();
+  const registryAddr = await registry.getAddress();
+
+  const Allowlist = await ethers.getContractFactory("Allowlist");
+  const allowlist = await Allowlist.deploy();
+  await allowlist.waitForDeployment();
+  const allowlistAddr = await allowlist.getAddress();
+
+  const out = {
+    chainId: Number((await ethers.provider.getNetwork()).chainId),
+    registry: registryAddr,
+    allowlist: allowlistAddr,
+    deployer: deployer.address,
+  };
+
+  const file = path.join(__dirname, "..", "deployed.local.json");
+  fs.writeFileSync(file, JSON.stringify(out, null, 2));
+
+  console.log(`IdentityRegistry: ${registryAddr}`);
+  console.log(`Allowlist:        ${allowlistAddr}`);
+  console.log(`Wrote ${file}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exitCode = 1;
+});

--- a/src/Tessera.Chains.Evm.Tests/EvmRegistrationSignerTests.cs
+++ b/src/Tessera.Chains.Evm.Tests/EvmRegistrationSignerTests.cs
@@ -54,6 +54,27 @@ public class EvmRegistrationSignerTests
     }
 
     [Fact]
+    public void StructHash_MatchesSolidityAbiEncode()
+    {
+        // Known-good value from ethers AbiCoder (matches Solidity abi.encode) for the fixed inputs.
+        const string expected = "0xd39dcaefeed412bc6a6cceeff6080544ea5619375304d4d9e8a41e20e161561d";
+        var actual = "0x" + Convert.ToHexString(EvmRegistrationSigner.StructHash(DidHash, Root, 97, Contract)).ToLowerInvariant();
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void Signature_IsLowS_PerEip2()
+    {
+        // The contract's _recover rejects the upper half of the curve order (EIP-2) to block
+        // malleability. Nethereum's own recovery accepts both halves, so only this explicit bound
+        // catches a high-S signature — exactly the gap that let the live registerDid revert.
+        var halfN = BigInteger.Parse("7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0", System.Globalization.NumberStyles.HexNumber);
+        var sig = EvmRegistrationSigner.Sign(Key, DidHash, Root, 97, Contract);
+        var s = new BigInteger(sig[32..64], isUnsigned: true, isBigEndian: true);
+        Assert.True(s <= halfN, $"signature S must be in the low half (EIP-2); got high-S {s:X}");
+    }
+
+    [Fact]
     public void Signature_IsBoundToChainId()
     {
         var controller = EvmRegistrationSigner.DeriveController(Key);

--- a/src/Tessera.Chains.Evm/Internal/EvmRegistrationSigner.cs
+++ b/src/Tessera.Chains.Evm/Internal/EvmRegistrationSigner.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Numerics;
 using System.Text;
 using Nethereum.ABI;
@@ -15,8 +16,8 @@ namespace Tessera.Chains.Evm.Internal;
 /// The signed payload mirrors the contract exactly:
 /// <code>
 /// structHash = keccak256(abi.encode(didHash, attestationRoot, chainId, contractAddress));
-/// digest     = keccak256("\x19Ethereum Signed Message:\n32", structHash);   // EIP-191 personal sign
-/// signature  = ECDSA_sign(digest, controllerKey);                            // 65 bytes, r‖s‖v
+/// digest     = keccak256(0x19 ++ "Ethereum Signed Message:\n32" ++ structHash);   // EIP-191 personal sign
+/// signature  = ECDSA_sign(digest, controllerKey);                                  // 65 bytes, r‖s‖v
 /// </code>
 /// Binding <c>chainId</c> and <c>contractAddress</c> into the struct hash prevents replaying the
 /// signature on another chain or another registry deployment.
@@ -25,8 +26,13 @@ internal static class EvmRegistrationSigner
 {
     private static readonly ABIEncode Abi = new();
 
-    // EIP-191 personal-sign prefix for a fixed 32-byte message (the struct hash is always 32 bytes).
-    private static readonly byte[] Eip191Prefix32 = Encoding.ASCII.GetBytes("\x19Ethereum Signed Message:\n32");
+    // EIP-191 personal-sign prefix for a fixed 32-byte message (the struct hash is always 32 bytes):
+    // the 0x19 control byte followed by "Ethereum Signed Message:\n32". Built as explicit bytes so no
+    // control char or \x escape lives in a string literal — a literal "\x19Ethereum…" is a trap, since
+    // C#'s variable-length \x greedily consumes the following 'E' (\x19E -> U+019E) and corrupts the
+    // prefix, yielding a digest the contract's ecrecover does not match (-> InvalidSignature).
+    private static readonly byte[] Eip191Prefix32 =
+        new byte[] { 0x19 }.Concat(Encoding.ASCII.GetBytes("Ethereum Signed Message:\n32")).ToArray();
 
     /// <summary>The address that controls the DID, derived from the signing key.</summary>
     public static string DeriveController(string privateKey) => new EthECKey(privateKey).GetPublicAddress();
@@ -46,7 +52,7 @@ internal static class EvmRegistrationSigner
     }
 
     /// <summary>
-    /// keccak256("\x19Ethereum Signed Message:\n32" ‖ structHash) — the exact digest the contract
+    /// keccak256(0x19 ++ "Ethereum Signed Message:\n32" ++ structHash) — the exact digest the contract
     /// signs over (EIP-191 personal-sign of the 32-byte struct hash).
     /// </summary>
     public static byte[] Digest(byte[] structHash)


### PR DESCRIPTION
The EvmChainAnchor / EvmAllowlistGateway smoke tests are [SkippableFact]-gated on TESSERA_EVM_* and were silently skipping in CI. Give them a real chain.

- scripts/deploy-local.js: deploy IdentityRegistry + Allowlist to a local node, write addresses to deployed.local.json (gitignored).
- New evm-smoke job in dotnet.yml: spin up `npx hardhat node`, deploy, export the addresses, then `dotnet test` the EVM project against it (account #0 key).
- .env.local.example: reproducible local setup (stock Hardhat throwaway key).
- .gitignore: deployed.local.json.