### PR TITLE
Feat/v3.3 snapshot homomorphic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ inward. No vendor, network, token, or business-schema names in the core.
 
 ### Added
 
+- **Point-in-time snapshot binding** (`Tessera.Sources.Bitcoin` + `Tessera.Attestations`): every
+  Bitcoin attestation now binds a chain snapshot — best-block height, hash, and time — captured once
+  per fact computation via the new `IBitcoinProvider.GetChainTipAsync` (`EsploraBitcoinProvider` reads
+  `/blocks/tip/height` + `/blocks/tip/hash` and the tip block's time). The snapshot rides in each
+  payload's claims via the generic `Tessera.Attestations.ChainSnapshot` (public chain data — no
+  address/txid/amount, so the privacy invariant holds; the leak test now asserts the snapshot is
+  present while secrets stay absent). Honest scope: it records the tip at issuance time, not historical
+  verification at a past height (that needs an indexer).
+- **`SnapshotFreshness` verification rule** (`Tessera.Sdk`): opt-in (default off)
+  `SnapshotFreshnessRequirement` on `VerificationPolicy` fails a presentation whose snapshot is older
+  than a max age in time (`MaxAge`) and/or in blocks (`MaxAgeBlocks` + the verifier's
+  `CurrentBlockHeight`), with reason `snapshot_stale:{type}`. `VerifierOptions.Clock` (a `TimeProvider`)
+  drives the time check; read a snapshot off any disclosure with `ChainSnapshot.TryFrom(payload)`.
+- **Homomorphic predicate helpers** (`Tessera.Attestations.CredentialProof`): `CombineCommitments` and
+  `CombineOpenings` expose the additive homomorphism of Pedersen commitments, so a bound predicate over
+  a sum or difference of commitments (`C₁ ± C₂ ± … ≥ threshold`) is provable with the existing
+  range-proof math — no proof-math change. The prover combines openings + value and calls
+  `ProveBoundMinimum`; the verifier combines commitments and calls `VerifyBound`.
 - **Bitcoin attestation source** (`Tessera.Sources.Bitcoin`): turns proven control of Bitcoin
   addresses into attestations — the basis for "private proof-of-Bitcoin". A holder proves control by
   signing a domain-separated, anti-replay challenge (`BitcoinChallenge` + `INonceStore`); BIP-137

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ the `Sagynbaev.Tessera.Sdk` package); namespaces remain `Tessera.*`.
 | `Tessera.Sdk` | **Entry point for most consumers.** High-level `Holder`, `Issuer`, `Verifier` facades. |
 | `Tessera.Core` | `DidId`, `Base58`. Zero external dependencies. |
 | `Tessera.Did` | `DidDocument`, `DidService`, `IDidStore`, wallet/channel binding, revocation. |
-| `Tessera.Attestations` | `Attestation`, `AttestationIssuer`, `MerkleTree`, `AttestationVerifier`, `PresentationVerifier`, `IIssuerRegistry`, `CredentialProof`. |
+| `Tessera.Attestations` | `Attestation`, `AttestationIssuer`, `MerkleTree`, `AttestationVerifier`, `PresentationVerifier`, `IIssuerRegistry`, `CredentialProof` (incl. `CombineCommitments`/`CombineOpenings` for predicates over a sum/difference of commitments), `ChainSnapshot`. |
 | `Tessera.Cryptography` | Pure-C# secp256k1, Pedersen commitments, Bulletproofs (no external deps). |
 | `Tessera.Signing` | Production Ed25519 (NSec / libsodium). Drop-in `Ed25519Verifier` and `Ed25519IssuerSigner`. |
 | `Tessera.EntityFrameworkCore` | EF Core `IDidStore` and `IIssuerRegistry` over any relational provider (Postgres, SQL Server, SQLite). |
@@ -54,7 +54,7 @@ the `Sagynbaev.Tessera.Sdk` package); namespaces remain `Tessera.*`.
 | `Tessera.Chains.Evm` | Generic EVM adapter (Nethereum): `EvmChainAnchor` + `EvmAllowlistGateway`, any chainId/RPC. |
 | `Tessera.Sources.Sumsub` | Layer-2 plugin: Sumsub KYC → `kyc_verified` / `jurisdiction` attestations. |
 | `Tessera.Sources.XRoad` | Layer-2 plugin: X-Road government registry → residency / property / encumbrance. |
-| `Tessera.Sources.Bitcoin` | Layer-2 plugin: proven control of Bitcoin addresses (BIP-137 signed challenge) → `btc_control` (address count only) + Pedersen-committed `btc_balance` / `btc_hodl_age`. Esplora (mempool.space / blockstream.info) provider. |
+| `Tessera.Sources.Bitcoin` | Layer-2 plugin: proven control of Bitcoin addresses (BIP-137 signed challenge) → `btc_control` (address count only) + Pedersen-committed `btc_balance` / `btc_hodl_age`, each bound to a point-in-time chain snapshot (height/hash/time). Esplora (mempool.space / blockstream.info) provider. |
 
 > **Audit status:** v3.2.0 is a security-hardening release (authenticated holder
 > presentations, fail-closed revocation, address-bound wallet binding, authenticated

--- a/examples/BitcoinCreditLine/Program.cs
+++ b/examples/BitcoinCreditLine/Program.cs
@@ -257,4 +257,12 @@ sealed class SimulatedBitcoinProvider : IBitcoinProvider
         };
         return Task.FromResult((IReadOnlyList<BitcoinUtxo>)new[] { utxo });
     }
+
+    public Task<BitcoinChainTip> GetChainTipAsync(CancellationToken ct = default)
+        => Task.FromResult(new BitcoinChainTip
+        {
+            BlockHeight = 2_580_000, // a plausible testnet tip for the demo
+            BlockHash = "00000000000000000000000000000000000000000000000000000000deadbeef",
+            BlockTimeUtc = DateTimeOffset.UtcNow,
+        });
 }

--- a/src/Tessera.Attestations.Tests/CredentialProofBindingTests.cs
+++ b/src/Tessera.Attestations.Tests/CredentialProofBindingTests.cs
@@ -156,4 +156,63 @@ public class CredentialProofBindingTests
 
         Assert.True(cp.VerifyBound(commitment, bundle));
     }
+
+    // ── Homomorphic predicates over combined commitments ─────────────────────
+    //
+    // Pedersen commitments are additively homomorphic, so a bound proof over a SUM or DIFFERENCE of
+    // commitments works with the existing range-proof math. Phrased purely as math (commitmentA/B/C).
+
+    [Fact]
+    public void CombinedCommitments_SumOfThree_AboveThreshold_VerifiesBound()
+    {
+        var cp = new CredentialProof();
+        const long valueA = 40, valueB = 35, valueC = 50; // sum = 125
+        const long publicThreshold = 100;
+
+        var (commitmentA, openingA) = cp.CommitValue(valueA);
+        var (commitmentB, openingB) = cp.CommitValue(valueB);
+        var (commitmentC, openingC) = cp.CommitValue(valueC);
+
+        // Verifier side: C = commitmentA + commitmentB + commitmentC.
+        var combinedCommitment = CredentialProof.CombineCommitments(
+            CredentialProof.CombineCommitments(commitmentA, commitmentB), commitmentC);
+
+        // Prover side: combined opening + combined value, proven ≥ threshold.
+        var combinedOpening = CredentialProof.CombineOpenings(
+            CredentialProof.CombineOpenings(openingA, openingB), openingC);
+        var bundle = cp.ProveBoundMinimum(valueA + valueB + valueC, publicThreshold, combinedOpening, "sum");
+
+        Assert.True(cp.VerifyBound(combinedCommitment, bundle));
+    }
+
+    [Fact]
+    public void CombinedCommitments_Difference_NonNegative_VerifiesBound()
+    {
+        var cp = new CredentialProof();
+        const long valueA = 120, valueB = 80; // A − B = 40 ≥ 0
+
+        var (commitmentA, openingA) = cp.CommitValue(valueA);
+        var (commitmentB, openingB) = cp.CommitValue(valueB);
+
+        var diffCommitment = CredentialProof.CombineCommitments(commitmentA, commitmentB, subtract: true);
+        var diffOpening = CredentialProof.CombineOpenings(openingA, openingB, subtract: true);
+        var bundle = cp.ProveBoundMinimum(valueA - valueB, 0, diffOpening, "diff");
+
+        Assert.True(cp.VerifyBound(diffCommitment, bundle));
+    }
+
+    [Fact]
+    public void CombinedCommitments_Difference_Negative_ProverCannotProve()
+    {
+        var cp = new CredentialProof();
+        const long valueA = 60, valueB = 100; // A − B = −40 < 0
+
+        var (_, openingA) = cp.CommitValue(valueA);
+        var (_, openingB) = cp.CommitValue(valueB);
+        var diffOpening = CredentialProof.CombineOpenings(openingA, openingB, subtract: true);
+
+        // A prover with valueA < valueB cannot produce a passing bundle: the shifted value is negative,
+        // so ProveBoundMinimum refuses to build a proof at all.
+        Assert.Throws<ArgumentException>(() => cp.ProveBoundMinimum(valueA - valueB, 0, diffOpening, "diff"));
+    }
 }

--- a/src/Tessera.Attestations/ChainSnapshot.cs
+++ b/src/Tessera.Attestations/ChainSnapshot.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+
+namespace Tessera.Attestations;
+
+/// <summary>
+/// A point-in-time blockchain reference — the best block at the moment a fact was observed: height,
+/// block hash, and time. Generic chain infrastructure (no vendor or use-case semantics): a source
+/// writes it into an attestation payload's claims so a verifier can freshness-check <em>when</em> a
+/// fact was true. It is public chain data and carries no subject-identifying information, so it does
+/// not weaken any privacy invariant.
+/// </summary>
+/// <remarks>
+/// Stored in <see cref="AttestationPayload.Claims"/> under the three <c>snapshot_*</c> keys below.
+/// The time is persisted as Unix seconds (a long) rather than a formatted timestamp so the canonical
+/// signing bytes are culture-invariant and identical across implementations.
+/// </remarks>
+public sealed record ChainSnapshot
+{
+    /// <summary>Height of the snapshot block.</summary>
+    public required long BlockHeight { get; init; }
+
+    /// <summary>Hash of the snapshot block (hex).</summary>
+    public required string BlockHash { get; init; }
+
+    /// <summary>Time of the snapshot block.</summary>
+    public required DateTimeOffset TimeUtc { get; init; }
+
+    /// <summary>Claim key carrying <see cref="BlockHeight"/>.</summary>
+    public const string BlockHeightClaim = "snapshot_block_height";
+
+    /// <summary>Claim key carrying <see cref="BlockHash"/>.</summary>
+    public const string BlockHashClaim = "snapshot_block_hash";
+
+    /// <summary>Claim key carrying <see cref="TimeUtc"/> as Unix seconds.</summary>
+    public const string TimeClaim = "snapshot_time_unix_s";
+
+    /// <summary>Merge this snapshot's three fields into a claims dictionary the caller is building.</summary>
+    public void WriteClaims(IDictionary<string, object> claims)
+    {
+        ArgumentNullException.ThrowIfNull(claims);
+        claims[BlockHeightClaim] = BlockHeight;
+        claims[BlockHashClaim] = BlockHash;
+        claims[TimeClaim] = TimeUtc.ToUnixTimeSeconds();
+    }
+
+    /// <summary>
+    /// Read the snapshot from an attestation payload, or null when the payload carries no snapshot
+    /// (or it is malformed). The public read path for verifiers and downstream callers.
+    /// </summary>
+    public static ChainSnapshot? TryFrom(AttestationPayload? payload)
+        => payload is null ? null : TryFrom(payload.Claims);
+
+    /// <summary>Read the snapshot from a claims dictionary, or null when absent/malformed.</summary>
+    public static ChainSnapshot? TryFrom(IReadOnlyDictionary<string, object>? claims)
+    {
+        if (claims is null) return null;
+        if (!claims.TryGetValue(BlockHeightClaim, out var heightObj)
+            || !claims.TryGetValue(BlockHashClaim, out var hashObj)
+            || !claims.TryGetValue(TimeClaim, out var timeObj))
+            return null;
+
+        if (!TryToLong(heightObj, out var height) || !TryToLong(timeObj, out var unixSeconds))
+            return null;
+
+        var hash = hashObj as string ?? hashObj?.ToString();
+        if (string.IsNullOrEmpty(hash)) return null;
+
+        return new ChainSnapshot
+        {
+            BlockHeight = height,
+            BlockHash = hash,
+            TimeUtc = DateTimeOffset.FromUnixTimeSeconds(unixSeconds),
+        };
+    }
+
+    // Claims survive in memory as the boxed types a source wrote (long), but may arrive as a string
+    // or JsonElement after a JSON round-trip — accept all so reads are robust to the transport.
+    private static bool TryToLong(object? value, out long result)
+    {
+        switch (value)
+        {
+            case long l: result = l; return true;
+            case int i: result = i; return true;
+            case string s when long.TryParse(s, out var parsed): result = parsed; return true;
+            case JsonElement je when je.ValueKind == JsonValueKind.Number && je.TryGetInt64(out var n):
+                result = n; return true;
+            case JsonElement je when je.ValueKind == JsonValueKind.String && long.TryParse(je.GetString(), out var ns):
+                result = ns; return true;
+            default: result = 0; return false;
+        }
+    }
+}

--- a/src/Tessera.Attestations/CredentialProof.cs
+++ b/src/Tessera.Attestations/CredentialProof.cs
@@ -199,6 +199,54 @@ namespace Tessera.Attestations
             catch { return false; }
         }
 
+        // ── Homomorphic predicate helpers ────────────────────────────────────
+        //
+        // Pedersen commitments are additively homomorphic: C₁ ± C₂ commits to value₁ ± value₂ under
+        // blinding r₁ ± r₂. Because VerifyBound takes the commitment point from the caller, a predicate
+        // over a SUM or DIFFERENCE of commitments (C₁ ± C₂ ± … ≥ threshold) is provable with the
+        // EXISTING range-proof math — these helpers just expose the point/scalar arithmetic so NuGet
+        // consumers can assemble the combined commitment and opening. No proof math changes here.
+
+        /// <summary>
+        /// Homomorphically combine two Pedersen commitments: <c>Decode(a) ± Decode(b)</c>, re-encoded.
+        /// The result commits to the sum (or, when <paramref name="subtract"/> is true, the difference)
+        /// of the two committed values under the sum/difference of their blindings.
+        /// </summary>
+        /// <remarks>
+        /// To prove <c>valueA ± valueB ≥ threshold</c> over committed values without revealing them:
+        /// the prover (who holds both openings) computes the combined value and
+        /// <c>opening = CombineOpenings(openingA, openingB, subtract)</c>, then calls
+        /// <see cref="ProveBoundMinimum(long, long, byte[], string)"/> with the combined value, the
+        /// threshold, that opening, and a label. The verifier computes
+        /// <c>C = CombineCommitments(commitmentA, commitmentB, subtract)</c> and calls
+        /// <see cref="VerifyBound(byte[], CredentialBundle)"/> with <c>C</c> and the bundle.
+        /// </remarks>
+        public static byte[] CombineCommitments(byte[] a, byte[] b, bool subtract = false)
+        {
+            ArgumentNullException.ThrowIfNull(a);
+            ArgumentNullException.ThrowIfNull(b);
+            var pa = Point.Decode(a);
+            var pb = Point.Decode(b);
+            var combined = subtract ? pa - pb : pa + pb;
+            return combined.Encode();
+        }
+
+        /// <summary>
+        /// Combine two Pedersen openings (blindings): <c>Scalar(a) ± Scalar(b)</c>, re-encoded. Pair with
+        /// <see cref="CombineCommitments"/> using the same <paramref name="subtract"/> flag so the
+        /// combined opening matches the combined commitment. See <see cref="CombineCommitments"/> for the
+        /// full prover/verifier flow.
+        /// </summary>
+        public static byte[] CombineOpenings(byte[] a, byte[] b, bool subtract = false)
+        {
+            ArgumentNullException.ThrowIfNull(a);
+            ArgumentNullException.ThrowIfNull(b);
+            var sa = Scalar.FromBytes(a);
+            var sb = Scalar.FromBytes(b);
+            var combined = subtract ? sa - sb : sa + sb;
+            return combined.ToBytes();
+        }
+
         public string Serialize(CredentialBundle bundle)
         {
             using var ms = new MemoryStream();

--- a/src/Tessera.Sdk.Tests/PolicyEvaluationTests.cs
+++ b/src/Tessera.Sdk.Tests/PolicyEvaluationTests.cs
@@ -318,4 +318,132 @@ public class PolicyEvaluationTests
             ClaimPolicy(new RequiredClaim { Type = "jurisdiction", Key = "country" }));
         Assert.True(r.Valid, r.Reason);
     }
+
+    // ── snapshot freshness (opt-in, default off) ─────────────────────────────
+
+    private static readonly DateTimeOffset SnapNow = new(2026, 6, 14, 12, 0, 0, TimeSpan.Zero);
+
+    private static AttestationDisclosure SnapshotDisclosure(string type, ChainSnapshot snapshot)
+    {
+        var claims = new Dictionary<string, object>();
+        snapshot.WriteClaims(claims);
+        return new AttestationDisclosure
+        {
+            Attestation = new Attestation
+            {
+                Schema = "s",
+                Type = type,
+                Issuer = new DidId("did:tessera:issuer"),
+                Subject = new DidId("did:tessera:subject"),
+                IssuedAt = DateTimeOffset.UnixEpoch,
+                Nonce = new byte[16],
+                Payload = new AttestationPayload { Method = "m", Claims = claims },
+                Signature = new AttestationSignature { Algorithm = "ed25519", Value = new byte[64] },
+            },
+            MerkleProof = new MerkleInclusionProof
+            {
+                LeafHash = new byte[32], Path = Array.Empty<byte[]>(), Root = new byte[32], LeafIndex = 0,
+            },
+        };
+    }
+
+    private static VerificationPolicy FreshnessPolicy(SnapshotFreshnessRequirement req) => new()
+    {
+        ExpectedVerifier = new DidId("did:tessera:v"),
+        SnapshotFreshness = req,
+    };
+
+    [Fact]
+    public void Snapshot_NoRule_Passes_EvenWhenOld()
+    {
+        var old = new ChainSnapshot { BlockHeight = 1, BlockHash = "h", TimeUtc = SnapNow.AddYears(-1) };
+        var r = PolicyEvaluation.EvaluateDeclarativeRules(
+            Present(SnapshotDisclosure("btc_balance", old)),
+            new VerificationPolicy { ExpectedVerifier = new DidId("did:tessera:v") },
+            SnapNow);
+        Assert.True(r.Valid, r.Reason);
+    }
+
+    [Fact]
+    public void Snapshot_FreshByTime_Passes()
+    {
+        var fresh = new ChainSnapshot { BlockHeight = 900_000, BlockHash = "h", TimeUtc = SnapNow.AddHours(-1) };
+        var r = PolicyEvaluation.EvaluateDeclarativeRules(
+            Present(SnapshotDisclosure("btc_balance", fresh)),
+            FreshnessPolicy(new SnapshotFreshnessRequirement { MaxAge = TimeSpan.FromHours(6) }),
+            SnapNow);
+        Assert.True(r.Valid, r.Reason);
+    }
+
+    [Fact]
+    public void Snapshot_StaleByTime_Fails()
+    {
+        var stale = new ChainSnapshot { BlockHeight = 900_000, BlockHash = "h", TimeUtc = SnapNow.AddDays(-3) };
+        var r = PolicyEvaluation.EvaluateDeclarativeRules(
+            Present(SnapshotDisclosure("btc_balance", stale)),
+            FreshnessPolicy(new SnapshotFreshnessRequirement { MaxAge = TimeSpan.FromHours(6) }),
+            SnapNow);
+        Assert.False(r.Valid);
+        Assert.Equal("snapshot_stale:btc_balance", r.Reason);
+    }
+
+    [Fact]
+    public void Snapshot_FreshByBlocks_Passes()
+    {
+        var snap = new ChainSnapshot { BlockHeight = 900_000, BlockHash = "h", TimeUtc = SnapNow };
+        var r = PolicyEvaluation.EvaluateDeclarativeRules(
+            Present(SnapshotDisclosure("btc_balance", snap)),
+            FreshnessPolicy(new SnapshotFreshnessRequirement { MaxAgeBlocks = 6, CurrentBlockHeight = 900_003 }),
+            SnapNow);
+        Assert.True(r.Valid, r.Reason);
+    }
+
+    [Fact]
+    public void Snapshot_StaleByBlocks_Fails()
+    {
+        var snap = new ChainSnapshot { BlockHeight = 900_000, BlockHash = "h", TimeUtc = SnapNow };
+        var r = PolicyEvaluation.EvaluateDeclarativeRules(
+            Present(SnapshotDisclosure("btc_balance", snap)),
+            FreshnessPolicy(new SnapshotFreshnessRequirement { MaxAgeBlocks = 6, CurrentBlockHeight = 900_100 }),
+            SnapNow);
+        Assert.False(r.Valid);
+        Assert.Equal("snapshot_stale:btc_balance", r.Reason);
+    }
+
+    [Fact]
+    public void Snapshot_BlockRule_WithoutCurrentHeight_SkipsBlockCheck()
+    {
+        var snap = new ChainSnapshot { BlockHeight = 900_000, BlockHash = "h", TimeUtc = SnapNow };
+        var r = PolicyEvaluation.EvaluateDeclarativeRules(
+            Present(SnapshotDisclosure("btc_balance", snap)),
+            FreshnessPolicy(new SnapshotFreshnessRequirement { MaxAgeBlocks = 6 }), // no CurrentBlockHeight
+            SnapNow);
+        Assert.True(r.Valid, r.Reason); // no reference height → block check is a no-op
+    }
+
+    [Fact]
+    public void Snapshot_TypeFilter_IgnoresUntargetedDisclosures()
+    {
+        var stale = new ChainSnapshot { BlockHeight = 1, BlockHash = "h", TimeUtc = SnapNow.AddDays(-30) };
+        var r = PolicyEvaluation.EvaluateDeclarativeRules(
+            Present(SnapshotDisclosure("kyc_verified", stale)),
+            FreshnessPolicy(new SnapshotFreshnessRequirement
+            {
+                Types = new[] { "btc_balance" }, // the stale disclosure is a different type
+                MaxAge = TimeSpan.FromHours(6),
+            }),
+            SnapNow);
+        Assert.True(r.Valid, r.Reason);
+    }
+
+    [Fact]
+    public void Snapshot_NoSnapshotOnDisclosure_IsSkipped()
+    {
+        // A disclosure carrying no snapshot is not failed by the freshness rule.
+        var r = PolicyEvaluation.EvaluateDeclarativeRules(
+            Present(Disclosure("btc_balance")),
+            FreshnessPolicy(new SnapshotFreshnessRequirement { MaxAge = TimeSpan.FromHours(6) }),
+            SnapNow);
+        Assert.True(r.Valid, r.Reason);
+    }
 }

--- a/src/Tessera.Sdk/VerificationPolicyRules.cs
+++ b/src/Tessera.Sdk/VerificationPolicyRules.cs
@@ -33,6 +33,43 @@ public sealed record PredicateRequirement
 }
 
 /// <summary>
+/// An opt-in freshness requirement on the point-in-time <see cref="ChainSnapshot"/> carried by
+/// disclosed attestations. A presentation fails when a targeted disclosure's snapshot is older than
+/// the allowed age — by wall-clock time, by block count, or both. Default-off: a policy with no
+/// <see cref="VerificationPolicy.SnapshotFreshness"/> performs no snapshot check.
+/// </summary>
+/// <remarks>
+/// The snapshot rides in the issuer-signed canonical claims, so it cannot be tampered post-issue.
+/// Disclosures that carry no snapshot are skipped — this rule freshness-checks snapshots that are
+/// present, it does not mandate their presence (use <see cref="VerificationPolicy.RequiredTypes"/>
+/// to mandate a type). The block-age check runs only when <see cref="CurrentBlockHeight"/> is set,
+/// since the verifier — not the library — knows the current chain tip.
+/// </remarks>
+public sealed record SnapshotFreshnessRequirement
+{
+    /// <summary>
+    /// Attestation types to enforce freshness on. Empty (default) = every disclosure that carries a
+    /// snapshot.
+    /// </summary>
+    public IReadOnlyList<string> Types { get; init; } = Array.Empty<string>();
+
+    /// <summary>Maximum allowed wall-clock age (now − snapshot time). Null = no time-based check.</summary>
+    public TimeSpan? MaxAge { get; init; }
+
+    /// <summary>
+    /// Maximum allowed age in blocks (<see cref="CurrentBlockHeight"/> − snapshot height). Null = no
+    /// block-based check. Requires <see cref="CurrentBlockHeight"/> to take effect.
+    /// </summary>
+    public long? MaxAgeBlocks { get; init; }
+
+    /// <summary>
+    /// The verifier's current chain-tip height, supplied at verification time for the block-age check.
+    /// Null = the block-age check is skipped (no reference height available).
+    /// </summary>
+    public long? CurrentBlockHeight { get; init; }
+}
+
+/// <summary>
 /// A declarative claim-value requirement: a disclosed attestation of <see cref="Type"/> must carry
 /// claim <see cref="Key"/>, and (when <see cref="AllowedValues"/> is set) its value must be one of
 /// them. Claims are part of the issuer-signed canonical attestation, so this gates on trusted data.
@@ -79,7 +116,11 @@ public static class PredicateProofCodec
 /// </remarks>
 internal static class PolicyEvaluation
 {
+    /// <summary>Overload using the system clock for time-based checks (e.g. snapshot freshness).</summary>
     public static VerificationResult EvaluateDeclarativeRules(Presentation presentation, VerificationPolicy policy)
+        => EvaluateDeclarativeRules(presentation, policy, DateTimeOffset.UtcNow);
+
+    public static VerificationResult EvaluateDeclarativeRules(Presentation presentation, VerificationPolicy policy, DateTimeOffset now)
     {
         ArgumentNullException.ThrowIfNull(presentation);
         ArgumentNullException.ThrowIfNull(policy);
@@ -87,9 +128,34 @@ internal static class PolicyEvaluation
         // Evaluated in order; the first failing rule's reason is returned.
         var failure = CheckRequiredTypes(presentation, policy)
                    ?? CheckRequiredClaims(presentation, policy)
-                   ?? CheckPredicates(presentation, policy);
+                   ?? CheckPredicates(presentation, policy)
+                   ?? CheckSnapshotFreshness(presentation, policy, now);
 
         return failure is null ? VerificationResult.Ok() : VerificationResult.Fail(failure);
+    }
+
+    private static string? CheckSnapshotFreshness(Presentation presentation, VerificationPolicy policy, DateTimeOffset now)
+    {
+        var req = policy.SnapshotFreshness;
+        if (req is null) return null;
+
+        foreach (var disclosure in presentation.Disclosures)
+        {
+            var type = disclosure.Attestation.Type;
+            if (req.Types.Count > 0 && !req.Types.Contains(type, StringComparer.Ordinal))
+                continue;
+
+            var snapshot = ChainSnapshot.TryFrom(disclosure.Attestation.Payload);
+            if (snapshot is null) continue; // nothing to freshness-check on this disclosure
+
+            if (req.MaxAge is { } maxAge && now - snapshot.TimeUtc > maxAge)
+                return $"snapshot_stale:{type}";
+
+            if (req.MaxAgeBlocks is { } maxBlocks && req.CurrentBlockHeight is { } tip
+                && tip - snapshot.BlockHeight > maxBlocks)
+                return $"snapshot_stale:{type}";
+        }
+        return null;
     }
 
     private static string? CheckRequiredTypes(Presentation presentation, VerificationPolicy policy)

--- a/src/Tessera.Sdk/Verifier.cs
+++ b/src/Tessera.Sdk/Verifier.cs
@@ -119,9 +119,9 @@ public sealed class Verifier
         var cryptoResult = await _presVerifier.VerifyAsync(presentation, expectedRoot, ct).ConfigureAwait(false);
         if (!cryptoResult.Valid) return cryptoResult;
 
-        // 7. Declarative rules: required attestation types + predicate requirements.
-        //    Evaluated last, only on an otherwise-valid presentation.
-        return PolicyEvaluation.EvaluateDeclarativeRules(presentation, policy);
+        // 7. Declarative rules: required types + predicate requirements + snapshot freshness.
+        //    Evaluated last, only on an otherwise-valid presentation. Reuses the step-3 `now`.
+        return PolicyEvaluation.EvaluateDeclarativeRules(presentation, policy, now);
     }
 }
 
@@ -190,4 +190,11 @@ public sealed record VerificationPolicy
     /// Claims are part of the signed canonical attestation, so they cannot be tampered post-issue.
     /// </summary>
     public IReadOnlyList<RequiredClaim> RequiredClaims { get; init; } = Array.Empty<RequiredClaim>();
+
+    /// <summary>
+    /// Opt-in freshness requirement on the point-in-time <see cref="ChainSnapshot"/> carried by
+    /// disclosed attestations (e.g. a Bitcoin balance must be observed within the last N blocks or
+    /// the last N days). Null (default) = no snapshot check. Fails with <c>snapshot_stale:{type}</c>.
+    /// </summary>
+    public SnapshotFreshnessRequirement? SnapshotFreshness { get; init; }
 }

--- a/src/Tessera.Sdk/VerifierOptions.cs
+++ b/src/Tessera.Sdk/VerifierOptions.cs
@@ -18,7 +18,8 @@ public sealed record VerifierOptions
     public IChainAnchor? ChainAnchor { get; init; }
 
     /// <summary>
-    /// Clock used for presentation freshness checks (and attestation expiry). Defaults to
+    /// Clock used for presentation freshness checks (and attestation expiry), and for time-based
+    /// policy checks such as <see cref="VerificationPolicy.SnapshotFreshness"/>. Defaults to
     /// <see cref="TimeProvider.System"/>. Inject a fake provider in tests.
     /// </summary>
     public TimeProvider? Clock { get; init; }

--- a/src/Tessera.Sources.Bitcoin.Tests/BitcoinAttestationSourceTests.cs
+++ b/src/Tessera.Sources.Bitcoin.Tests/BitcoinAttestationSourceTests.cs
@@ -23,6 +23,12 @@ public class BitcoinAttestationSourceTests
     private const long V3 = 9_876_543_210_987;  // AddrB utxo3, 50 days old
     private const long ExpectedTotal = V1 + V2 + V3; // 11_111_111_101_110
 
+    // Chain-tip snapshot the fake provider reports. Distinct from every UTXO/amount/block-time above,
+    // and (for height/time) far from any scanned secret so the privacy assertions stay unambiguous.
+    private const long TipHeight = 850_321;
+    private const string TipHash = "0000000000000000000a1b2c3d4e5f60718293a4b5c6d7e8f900112233445566";
+    private const long TipTimeUnix = NowUnix; // tip ≈ now
+
     private sealed class FakeBitcoinProvider : IBitcoinProvider
     {
         private readonly Dictionary<string, (long Balance, BitcoinUtxo[] Utxos)> _data;
@@ -33,6 +39,14 @@ public class BitcoinAttestationSourceTests
 
         public Task<IReadOnlyList<BitcoinUtxo>> GetUtxosAsync(string address, CancellationToken ct = default)
             => Task.FromResult((IReadOnlyList<BitcoinUtxo>)_data[address].Utxos);
+
+        public Task<BitcoinChainTip> GetChainTipAsync(CancellationToken ct = default)
+            => Task.FromResult(new BitcoinChainTip
+            {
+                BlockHeight = TipHeight,
+                BlockHash = TipHash,
+                BlockTimeUtc = DateTimeOffset.FromUnixTimeSeconds(TipTimeUnix),
+            });
     }
 
     private static BitcoinUtxo Utxo(string txid, long value, int ageDays) => new()
@@ -72,6 +86,11 @@ public class BitcoinAttestationSourceTests
         Assert.Equal(2, result.Facts.AddressCount);
         // Σ(value·age)/total = 596_172_839_450_580 / 11_111_111_101_110 = 53 (floor).
         Assert.Equal(53, result.Facts.HodlAgeDays);
+
+        // The chain tip captured once up front is carried on the facts.
+        Assert.Equal(TipHeight, result.Facts.SnapshotBlockHeight);
+        Assert.Equal(TipHash, result.Facts.SnapshotBlockHash);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(TipTimeUnix), result.Facts.SnapshotTimeUtc);
     }
 
     [Fact]
@@ -86,15 +105,29 @@ public class BitcoinAttestationSourceTests
         Assert.Null(control.Payload.Commitment);
         Assert.NotNull(control.Payload.Claims);
         Assert.Equal(2, control.Payload.Claims![BitcoinAttestationTypes.AddressCountClaim]);
-        Assert.Single(control.Payload.Claims); // ONLY the count
+        // The count PLUS the three snapshot fields — and nothing else.
+        Assert.Equal(4, control.Payload.Claims.Count);
 
         var balance = result.Drafts.Single(d => d.Type == BitcoinAttestationTypes.Balance);
         Assert.NotNull(balance.Payload.Commitment);
-        Assert.Null(balance.Payload.Claims);
+        // Committed draft carries the snapshot only — no plaintext amount.
+        Assert.NotNull(balance.Payload.Claims);
+        Assert.Equal(3, balance.Payload.Claims!.Count);
 
         var age = result.Drafts.Single(d => d.Type == BitcoinAttestationTypes.HodlAge);
         Assert.NotNull(age.Payload.Commitment);
-        Assert.Null(age.Payload.Claims);
+        Assert.NotNull(age.Payload.Claims);
+        Assert.Equal(3, age.Payload.Claims!.Count);
+
+        // Every draft binds to the same point-in-time chain snapshot.
+        foreach (var draft in result.Drafts)
+        {
+            var snapshot = ChainSnapshot.TryFrom(draft.Payload);
+            Assert.NotNull(snapshot);
+            Assert.Equal(TipHeight, snapshot!.BlockHeight);
+            Assert.Equal(TipHash, snapshot.BlockHash);
+            Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(TipTimeUnix), snapshot.TimeUtc);
+        }
 
         Assert.True(result.Openings.ContainsKey(BitcoinAttestationTypes.Balance));
         Assert.True(result.Openings.ContainsKey(BitcoinAttestationTypes.HodlAge));
@@ -226,5 +259,19 @@ public class BitcoinAttestationSourceTests
             Assert.DoesNotContain(secret, fullText, StringComparison.Ordinal);
         foreach (var secret in longSecrets.Concat(smallSecrets))
             Assert.DoesNotContain(secret, humanText, StringComparison.Ordinal);
+
+        // ── The snapshot IS present (public chain data, not a leak) ───────────────
+        // Every draft must carry the chain snapshot, and the snapshot fields must appear on the wire.
+        foreach (var draft in result.Drafts)
+        {
+            var snapshot = ChainSnapshot.TryFrom(draft.Payload);
+            Assert.NotNull(snapshot);
+            Assert.Equal(TipHeight, snapshot!.BlockHeight);
+            Assert.Equal(TipHash, snapshot.BlockHash);
+            Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(TipTimeUnix), snapshot.TimeUtc);
+        }
+        Assert.Contains(TipHash, humanText, StringComparison.Ordinal);
+        Assert.Contains(TipHeight.ToString(), humanText, StringComparison.Ordinal);
+        Assert.Contains(TipTimeUnix.ToString(), humanText, StringComparison.Ordinal);
     }
 }

--- a/src/Tessera.Sources.Bitcoin.Tests/EsploraBitcoinProviderTests.cs
+++ b/src/Tessera.Sources.Bitcoin.Tests/EsploraBitcoinProviderTests.cs
@@ -78,6 +78,28 @@ public class EsploraBitcoinProviderTests
     }
 
     [Fact]
+    public async Task GetChainTip_ReadsHeightHashAndBlockTime()
+    {
+        const string tipHash = "0000000000000000000a1b2c3d4e5f60718293a4b5c6d7e8f900112233445566";
+        var handler = new StubHandler((req, _) =>
+        {
+            var path = req.RequestUri!.AbsolutePath;
+            if (path.EndsWith("/blocks/tip/height", StringComparison.Ordinal)) return Json("850321");
+            if (path.EndsWith("/blocks/tip/hash", StringComparison.Ordinal)) return Json(tipHash);
+            if (path.Contains("/block/", StringComparison.Ordinal))
+                return Json($$"""{"id":"{{tipHash}}","height":850321,"timestamp":1700000000}""");
+            return Json("not found", HttpStatusCode.NotFound);
+        });
+        var provider = Provider(handler);
+
+        var tip = await provider.GetChainTipAsync();
+
+        Assert.Equal(850321, tip.BlockHeight);
+        Assert.Equal(tipHash, tip.BlockHash);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1700000000), tip.BlockTimeUtc);
+    }
+
+    [Fact]
     public async Task RateLimited_AfterExhaustingAttempts_ThrowsTransient()
     {
         var handler = new StubHandler((_, _) => Json("slow down", HttpStatusCode.TooManyRequests));

--- a/src/Tessera.Sources.Bitcoin/BitcoinAttestationSource.cs
+++ b/src/Tessera.Sources.Bitcoin/BitcoinAttestationSource.cs
@@ -76,7 +76,17 @@ public sealed class BitcoinAttestationSource : IAttestationSource
             {
                 Drafts = Array.Empty<AttestationDraft>(),
                 Openings = new Dictionary<string, byte[]>(),
-                Facts = new BitcoinFacts { TotalSats = 0, HodlAgeDays = 0, OldestUtxoAgeDays = 0, AddressCount = 0 },
+                // Nothing is attested when no address is verified, so no chain snapshot is taken.
+                Facts = new BitcoinFacts
+                {
+                    TotalSats = 0,
+                    HodlAgeDays = 0,
+                    OldestUtxoAgeDays = 0,
+                    AddressCount = 0,
+                    SnapshotBlockHeight = 0,
+                    SnapshotBlockHash = "",
+                    SnapshotTimeUtc = default,
+                },
             };
         }
 
@@ -85,32 +95,44 @@ public sealed class BitcoinAttestationSource : IAttestationSource
         var drafts = new List<AttestationDraft>();
         var openings = new Dictionary<string, byte[]>(StringComparer.Ordinal);
 
-        // btc_control — boolean fact (≥1 address proven). Payload carries the COUNT only.
+        // The point-in-time snapshot every draft below binds to. Public chain data (height/hash/time);
+        // it carries no address, txid, or amount, so it does not breach the privacy invariant.
+        var snapshot = new ChainSnapshot
+        {
+            BlockHeight = facts.SnapshotBlockHeight,
+            BlockHash = facts.SnapshotBlockHash,
+            TimeUtc = facts.SnapshotTimeUtc,
+        };
+
+        // btc_control — boolean fact (≥1 address proven). Payload carries the COUNT plus the snapshot.
+        var controlClaims = new Dictionary<string, object>
+        {
+            [BitcoinAttestationTypes.AddressCountClaim] = facts.AddressCount,
+        };
+        snapshot.WriteClaims(controlClaims);
         drafts.Add(new AttestationDraft(
             BitcoinAttestationTypes.Control,
-            new AttestationPayload
-            {
-                Method = "btc_signmessage",
-                Claims = new Dictionary<string, object>
-                {
-                    [BitcoinAttestationTypes.AddressCountClaim] = facts.AddressCount,
-                },
-            },
+            new AttestationPayload { Method = "btc_signmessage", Claims = controlClaims },
             _options.ControlValidity));
 
         // btc_balance — Pedersen commitment to total confirmed sats; opening goes to the holder.
+        // The snapshot rides in the claims alongside the commitment (no plaintext amount).
         var (balanceCommitment, balanceOpening) = _credentialProof.CommitValue(facts.TotalSats);
+        var balanceClaims = new Dictionary<string, object>();
+        snapshot.WriteClaims(balanceClaims);
         drafts.Add(new AttestationDraft(
             BitcoinAttestationTypes.Balance,
-            new AttestationPayload { Method = "btc_confirmed_sats", Commitment = balanceCommitment },
+            new AttestationPayload { Method = "btc_confirmed_sats", Commitment = balanceCommitment, Claims = balanceClaims },
             _options.BalanceValidity));
         openings[BitcoinAttestationTypes.Balance] = balanceOpening;
 
         // btc_hodl_age — Pedersen commitment to value-weighted holding age (days).
         var (ageCommitment, ageOpening) = _credentialProof.CommitValue(facts.HodlAgeDays);
+        var ageClaims = new Dictionary<string, object>();
+        snapshot.WriteClaims(ageClaims);
         drafts.Add(new AttestationDraft(
             BitcoinAttestationTypes.HodlAge,
-            new AttestationPayload { Method = "btc_value_weighted_hodl_age_days", Commitment = ageCommitment },
+            new AttestationPayload { Method = "btc_value_weighted_hodl_age_days", Commitment = ageCommitment, Claims = ageClaims },
             _options.HodlAgeValidity));
         openings[BitcoinAttestationTypes.HodlAge] = ageOpening;
 

--- a/src/Tessera.Sources.Bitcoin/BitcoinFacts.cs
+++ b/src/Tessera.Sources.Bitcoin/BitcoinFacts.cs
@@ -24,6 +24,15 @@ public sealed record BitcoinFacts
 
     /// <summary>Number of addresses whose control was proven (the boolean <c>btc_control</c> fact).</summary>
     public required int AddressCount { get; init; }
+
+    /// <summary>Chain-tip block height at the moment these facts were observed (point-in-time binding).</summary>
+    public required long SnapshotBlockHeight { get; init; }
+
+    /// <summary>Chain-tip block hash (hex) at the moment these facts were observed.</summary>
+    public required string SnapshotBlockHash { get; init; }
+
+    /// <summary>Chain-tip block time at the moment these facts were observed.</summary>
+    public required DateTimeOffset SnapshotTimeUtc { get; init; }
 }
 
 /// <summary>
@@ -41,6 +50,11 @@ internal static class BitcoinFactCalculator
         CancellationToken ct)
     {
         var now = clock.GetUtcNow();
+
+        // Capture the chain tip ONCE up front: every fact below is observed "as of" this snapshot,
+        // so the emitted attestations bind to a single point in time rather than no moment at all.
+        var tip = await provider.GetChainTipAsync(ct).ConfigureAwait(false);
+
         long totalSats = 0;
         long oldestAgeDays = 0;
         long weightedAgeDenominator = 0;                   // Σ confirmed UTXO value (same set as the numerator)
@@ -76,6 +90,9 @@ internal static class BitcoinFactCalculator
             HodlAgeDays = hodlAgeDays,
             OldestUtxoAgeDays = oldestAgeDays,
             AddressCount = verified.Count,
+            SnapshotBlockHeight = tip.BlockHeight,
+            SnapshotBlockHash = tip.BlockHash,
+            SnapshotTimeUtc = tip.BlockTimeUtc,
         };
     }
 

--- a/src/Tessera.Sources.Bitcoin/EsploraBitcoinProvider.cs
+++ b/src/Tessera.Sources.Bitcoin/EsploraBitcoinProvider.cs
@@ -85,6 +85,30 @@ public sealed class EsploraBitcoinProvider : IBitcoinProvider, IDisposable
         }, ct);
     }
 
+    /// <inheritdoc/>
+    public Task<BitcoinChainTip> GetChainTipAsync(CancellationToken ct = default)
+    {
+        return BitcoinRetry.RunAsync(_retry, async () =>
+        {
+            // Esplora exposes the tip as plain-text height + hash; the tip block's header carries its time.
+            var heightText = await GetTextAsync("blocks/tip/height", ct).ConfigureAwait(false);
+            if (!long.TryParse(heightText.Trim(), out var height))
+                throw new InvalidOperationException($"Esplora returned a non-numeric tip height: '{heightText}'.");
+
+            var hash = (await GetTextAsync("blocks/tip/hash", ct).ConfigureAwait(false)).Trim();
+
+            using var block = await GetJsonAsync($"block/{Uri.EscapeDataString(hash)}", ct).ConfigureAwait(false);
+            var timestamp = block!.RootElement.GetProperty("timestamp").GetInt64();
+
+            return new BitcoinChainTip
+            {
+                BlockHeight = height,
+                BlockHash = hash,
+                BlockTimeUtc = DateTimeOffset.FromUnixTimeSeconds(timestamp),
+            };
+        }, ct);
+    }
+
     // ── HTTP helpers (mirror BlockfrostCardanoProvider) ──────────────────────────
 
     private async Task<JsonDocument?> GetJsonAsync(string path, CancellationToken ct, bool allowNotFound = false)
@@ -94,6 +118,15 @@ public sealed class EsploraBitcoinProvider : IBitcoinProvider, IDisposable
         var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
         if (!resp.IsSuccessStatusCode) throw ToException(resp.StatusCode, path, body);
         return JsonDocument.Parse(body);
+    }
+
+    /// <summary>GET a plain-text body (e.g. the tip height/hash endpoints, which are not JSON).</summary>
+    private async Task<string> GetTextAsync(string path, CancellationToken ct)
+    {
+        using var resp = await _http.GetAsync(path, ct).ConfigureAwait(false);
+        var body = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        if (!resp.IsSuccessStatusCode) throw ToException(resp.StatusCode, path, body);
+        return body;
     }
 
     /// <summary>Maps an Esplora error to the source taxonomy. 5xx/429 are transient (retryable).</summary>

--- a/src/Tessera.Sources.Bitcoin/IBitcoinProvider.cs
+++ b/src/Tessera.Sources.Bitcoin/IBitcoinProvider.cs
@@ -18,6 +18,26 @@ public interface IBitcoinProvider
     /// confirmed in (height + time). Unconfirmed UTXOs are excluded. Empty for an unused address.
     /// </summary>
     Task<IReadOnlyList<BitcoinUtxo>> GetUtxosAsync(string address, CancellationToken ct = default);
+
+    /// <summary>
+    /// The current chain tip: best-block height, hash, and time. Captured once per fact computation
+    /// so every emitted attestation records the point in time the balance/control was observed at.
+    /// Public chain data — carries no subject-identifying information.
+    /// </summary>
+    Task<BitcoinChainTip> GetChainTipAsync(CancellationToken ct = default);
+}
+
+/// <summary>The chain tip (best block) at a point in time: height, hash, and block time.</summary>
+public sealed record BitcoinChainTip
+{
+    /// <summary>Height of the best block.</summary>
+    public required long BlockHeight { get; init; }
+
+    /// <summary>Hash of the best block (hex).</summary>
+    public required string BlockHash { get; init; }
+
+    /// <summary>Time of the best block (from its header timestamp).</summary>
+    public required DateTimeOffset BlockTimeUtc { get; init; }
 }
 
 /// <summary>Confirmed balance summary for a single address, in satoshis.</summary>

--- a/src/Tessera.Sources.Bitcoin/README.md
+++ b/src/Tessera.Sources.Bitcoin/README.md
@@ -84,13 +84,35 @@ continuous custody. `total_sats` is a point-in-time confirmed balance and can ch
 
 | Type | Payload | Predicate |
 |---|---|---|
-| `btc_control` | `address_count` claim **only** (no addresses) | boolean: ≥ 1 address proven |
-| `btc_balance` | Pedersen commitment to `total_sats` | `ProveBoundMinimum` (e.g. `≥ 1 BTC`) |
-| `btc_hodl_age` | Pedersen commitment to `hodl_age_days` | `ProveBoundMinimum` (e.g. `≥ 365 days`) |
+| `btc_control` | `address_count` claim + chain snapshot (no addresses) | boolean: ≥ 1 address proven |
+| `btc_balance` | Pedersen commitment to `total_sats` + chain snapshot | `ProveBoundMinimum` (e.g. `≥ 1 BTC`) |
+| `btc_hodl_age` | Pedersen commitment to `hodl_age_days` + chain snapshot | `ProveBoundMinimum` (e.g. `≥ 365 days`) |
 
 These types live in this plugin (`BitcoinAttestationTypes`), not the vendor-neutral core — matching the
 X-Road plugin precedent. Register them with `BitcoinSchemas.Register(registry)` or
 `BitcoinSchemas.CreateStandardWithBitcoin()`.
+
+### Point-in-time snapshots
+
+A balance or control attestation with no chain reference asserts a fact about *no particular moment* —
+it can't be refreshed or freshness-checked. So every Bitcoin attestation binds a **chain snapshot**: the
+best block's height, hash, and time, captured **once** at the start of fact computation
+(`IBitcoinProvider.GetChainTipAsync`) and written into each payload's claims as the generic
+`snapshot_block_height` / `snapshot_block_hash` / `snapshot_time_unix_s` keys (see
+`Tessera.Attestations.ChainSnapshot`).
+
+This is **public chain data** — height, hash, time — so it does not weaken the privacy invariant: no
+address, txid, script, or plaintext amount is added. The privacy-leak test asserts the snapshot fields
+*are* present while secrets stay absent.
+
+A verifier opts into freshness with `VerificationPolicy.SnapshotFreshness` (a
+`SnapshotFreshnessRequirement`), bounding the snapshot's age by time (`MaxAge`) and/or by blocks
+(`MaxAgeBlocks` + the verifier's `CurrentBlockHeight`); it is **off by default**. Read a snapshot back
+from any disclosed attestation with `ChainSnapshot.TryFrom(attestation.Payload)`.
+
+> **Honest scope:** the snapshot records the chain tip *at issuance time*. It lets a verifier reject a
+> stale attestation, but it is **not** historical verification — checking the balance as it stood at a
+> specific past height would require an indexer and is out of scope for this plugin.
 
 ### Privacy invariant (hard rule)
 
@@ -109,10 +131,12 @@ committed and proven in **full satoshis**.
 
 ## Provider
 
-`IBitcoinProvider` abstracts chain data; `EsploraBitcoinProvider` implements it over the Esplora REST
-API (mempool.space / blockstream.info / self-hosted). Base URL is configurable; `BitcoinNetwork`
-selects Mainnet / Testnet / Signet defaults. Reads retry on transient faults (HTTP 5xx / 429 / network);
-the provider never writes. Unit tests mock the provider; a live mempool.space testnet read is exercised
+`IBitcoinProvider` abstracts chain data — confirmed balance, UTXOs, and the current chain tip
+(`GetChainTipAsync`, for the snapshot binding above). `EsploraBitcoinProvider` implements it over the
+Esplora REST API (mempool.space / blockstream.info / self-hosted), reading the tip from
+`/blocks/tip/height` + `/blocks/tip/hash` and the tip block's time. Base URL is configurable;
+`BitcoinNetwork` selects Mainnet / Testnet / Signet defaults. Reads retry on transient faults
+(HTTP 5xx / 429 / network); the provider never writes. Unit tests mock the provider; a live mempool.space testnet read is exercised
 by an integration test gated behind `TESSERA_BITCOIN_E2E=1`.
 
 > **Audit status:** the predicate proofs rest on `Tessera.Cryptography`, a from-scratch,


### PR DESCRIPTION
feat(bitcoin): bind a point-in-time chain snapshot into every attestation
A balance/control attestation with no chain reference asserts a fact about no
particular moment — it can't be refreshed or freshness-checked. Bind a chain
snapshot (best-block height, hash, time) into every Bitcoin attestation.

- IBitcoinProvider.GetChainTipAsync + BitcoinChainTip; EsploraBitcoinProvider
  reads /blocks/tip/height + /blocks/tip/hash and the tip block's time (retry).
- BitcoinFactCalculator captures the tip ONCE up front; BitcoinFacts carries
  SnapshotBlockHeight/Hash/TimeUtc, threaded into all three draft payloads.
- New generic Tessera.Attestations.ChainSnapshot (public chain data — no
  address/txid/amount; privacy invariant holds). Shape + privacy-leak tests now
  assert the snapshot IS present while secrets stay absent.
- Opt-in SnapshotFreshness rule on VerificationPolicy (max age in time and/or
  blocks; default off), driven by VerifierOptions.Clock; fails snapshot_stale.
  ChainSnapshot.TryFrom exposes the snapshot on any disclosure.
- README (Sources.Bitcoin): Point-in-time snapshots section, honest scope note.