### PR TITLE
docs(evm): changelog + README for the registerDid fix and live smoke CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **EVM `registerDid` controller signature was always rejected** (`Tessera.Chains.Evm`): the
+  registration signer built its EIP-191 prefix from the literal `"\x19Ethereum…"`, but C#'s `\x`
+  escape is variable-length — `\x19E` parses as the single char `U+019E` (E is a hex digit) and
+  corrupts the prefix. The signature was made over the wrong digest; Nethereum recovered it
+  self-consistently (so the signer unit test passed) while the contract's `ecrecover` used the correct
+  prefix and recovered a different signer, reverting `InvalidSignature` on every live `registerDid`.
+  Net effect: live EVM DID registration (anchoring a not-yet-registered DID) was broken in 3.2.0,
+  masked because the smoke tests are env-gated and skipped. Fixed by building the prefix as explicit
+  bytes (`0x19 ++ "Ethereum Signed Message:\n32"`); added regression tests asserting the struct hash
+  matches Solidity `abi.encode` and the signature is low-S per EIP-2.
+
+### Added
+
+- **Live EVM smoke tests in CI**: a new `evm-smoke` GitHub Actions job spins up a local Hardhat node,
+  deploys `IdentityRegistry` + `Allowlist`, and runs the `EvmChainAnchor` / `EvmAllowlistGateway`
+  smoke tests against it — so the on-chain anchor path is exercised on every push/PR instead of
+  silently skipping. `chains/evm/scripts/deploy-local.js` + `chains/evm/.env.local.example` make the
+  same run reproducible locally (it caught the `registerDid` regression above).
+
 ## [3.2.0] - 2026-06-13
 
 Chain-agnostic core extended for permissioned-token / compliance use cases, organized as three

--- a/chains/evm/README.md
+++ b/chains/evm/README.md
@@ -84,6 +84,28 @@ npm run deploy:bnbtestnet
 The deployer becomes the initial issuer-registry authority unless
 `TESSERA_EVM_AUTHORITY` overrides it.
 
+## Local smoke tests (C# adapter ↔ a real chain)
+
+The `EvmChainAnchor` / `EvmAllowlistGateway` smoke tests in `src/Tessera.Chains.Evm.Tests`
+are `[SkippableFact]`-gated on the `TESSERA_EVM_*` env vars, so they skip unless pointed at a
+live chain. Run them against a throwaway local Hardhat node — no funds, no faucet:
+
+```bash
+cd chains/evm
+npm ci && npx hardhat compile
+npx hardhat node &                                            # local chain on :8545
+npx hardhat run scripts/deploy-local.js --network localhost   # deploys both, writes deployed.local.json
+cp .env.local.example .env.local && set -a && . ./.env.local && set +a
+dotnet test ../../src/Tessera.Chains.Evm.Tests -c Release     # smoke tests now run live
+```
+
+`deploy-local.js` deploys `IdentityRegistry` + `Allowlist` and records their addresses in
+`deployed.local.json` (gitignored). `.env.local.example` uses the stock, publicly-known Hardhat
+account #0 — a throwaway key valid only on a local node; never put a real key there.
+
+CI runs exactly this in the **`evm-smoke`** GitHub Actions job, so the on-chain anchor path is
+exercised on every push/PR rather than silently skipping.
+
 ## C# client
 
 `src/Tessera.Chains.Evm/EvmChainAnchor` implements `IChainAnchor` against this


### PR DESCRIPTION
- CHANGELOG Unreleased: Fixed (EIP-191 \x19 prefix bug → registerDid InvalidSignature) and Added (evm-smoke CI job + reproducible local smoke run).
- chains/evm/README: "Local smoke tests" section (deploy-local.js + .env.local.example), and a note that the evm-smoke CI job runs the same flow.