### PR TITLE
docs: add community health files (CoC, PR/issue templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: 🐞 Bug report
+description: Report a reproducible problem in Tessera.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please do **not** report security
+        vulnerabilities here — see [SECURITY.md](../blob/main/SECURITY.md) for private reporting.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+      placeholder: When I call ..., I get ..., but I expected ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: A minimal code snippet or sequence of steps that triggers the issue.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+      render: text
+    validations:
+      required: true
+
+  - type: input
+    id: package-version
+    attributes:
+      label: Package & version
+      description: Which package(s) and version(s)? e.g. Sagynbaev.Tessera.Cryptography 3.3.0
+      placeholder: Sagynbaev.Tessera 3.3.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Cryptography (secp256k1 / Pedersen / Bulletproofs)
+        - Attestations / DID / presentations
+        - Chain anchor — EVM
+        - Chain anchor — Cardano
+        - Chain anchor — Solana
+        - Chain anchor — Stellar
+        - SDK / other
+        - Docs
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: .NET SDK version, OS, and anything else relevant.
+      placeholder: |
+        - .NET SDK: 8.0.x
+        - OS: Windows 11 / Ubuntu 24.04 / macOS 15
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / stack trace
+      description: Any relevant exception, stack trace, or output. This will be rendered as code.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/asagynbaev/Tessera/security/advisories/new
+    about: Do NOT open a public issue for security problems. Use private vulnerability reporting (see SECURITY.md).
+  - name: 💬 Questions & discussion
+    url: https://github.com/asagynbaev/Tessera/discussions
+    about: For usage questions, ideas, and open-ended discussion.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,60 @@
+name: ✨ Feature request
+description: Suggest a new capability or improvement for Tessera.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea! For large or breaking changes, please open an issue first so we
+        can agree on the approach before you invest time (see [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md)).
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do, and why is it hard or impossible today?
+      placeholder: I'm trying to ... but currently ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see? Sketch an API or behavior if you can.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Cryptography (secp256k1 / Pedersen / Bulletproofs)
+        - Attestations / DID / presentations
+        - Chain anchor — EVM
+        - Chain anchor — Cardano
+        - Chain anchor — Solana
+        - Chain anchor — Stellar
+        - New chain adapter
+        - SDK / developer experience
+        - Docs
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about, and why they fall short.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope check
+      description: Tessera is identity & reputation infrastructure — not a token, DAO, or DeFi toolkit.
+      options:
+        - label: This fits Tessera's scope as described in the README ("What this is for" / "What this is not for").
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!--
+Thanks for contributing to Tessera! Please fill out the sections below.
+See CONTRIBUTING.md for build/test instructions and the architecture rules.
+-->
+
+## Summary
+
+<!-- What does this PR change, and why? Link any related issue: Closes #123 -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behavior)
+- [ ] Docs / chore / CI only
+
+## Affected area
+
+<!-- e.g. Tessera.Cryptography, Tessera.Attestations, chains/evm, chains/cardano, docs -->
+
+## Checklist
+
+- [ ] `dotnet build TesseraSolution.sln -c Release` is green.
+- [ ] `dotnet test TesseraSolution.sln -c Release` is green.
+- [ ] New or changed behavior is covered by tests.
+- [ ] Commits follow **Conventional Commits** (`type(scope): summary`).
+- [ ] **[CHANGELOG.md](../CHANGELOG.md)** updated under `## [Unreleased]` for any user-visible change.
+- [ ] No vendor / product / use-case names leaked into the generic core (see [architecture rules](../CONTRIBUTING.md#architecture-rules)).
+- [ ] If contracts under `chains/` changed: checked-in artifacts (`abi/*.json`, `plutus.json`) are regenerated and in sync.
+- [ ] This PR does **not** contain a security vulnerability fix that should be reported privately first (see [SECURITY.md](../SECURITY.md)).
+
+## Notes for reviewers
+
+<!-- Anything reviewers should pay special attention to: trade-offs, follow-ups, out-of-scope items. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Code of Conduct
+
+Tessera adopts the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, as
+its Code of Conduct. The full canonical text is available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>.
+
+## Our pledge
+
+We as members, contributors, and maintainers pledge to make participation in our community a
+harassment-free experience for everyone, regardless of age, body size, visible or invisible
+disability, ethnicity, sex characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race, religion, or sexual
+identity and orientation. We pledge to act and interact in ways that contribute to an open,
+welcoming, diverse, inclusive, and healthy community.
+
+## Our standards
+
+Behavior that contributes to a positive environment includes:
+
+- Showing empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Taking responsibility, apologizing to those affected by our mistakes, and learning from them.
+- Focusing on what is best for the overall community.
+
+Unacceptable behavior includes harassment of any kind, personal or political attacks, publishing
+others' private information without explicit permission, and other conduct which could reasonably
+be considered inappropriate in a professional setting. The full list of standards is in the
+[canonical Contributor Covenant text](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately to
+the project maintainer, [@asagynbaev](https://github.com/asagynbaev). All complaints will be
+reviewed and investigated promptly and fairly. Maintainers are obligated to respect the privacy and
+security of the reporter of any incident.
+
+Maintainers who do not follow or enforce this Code of Conduct in good faith may face temporary or
+permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/>. Community Impact Guidelines were
+inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to Tessera
+
+Thanks for your interest in contributing. Tessera is a privacy-preserving, chain-agnostic identity
+and reputation library for .NET. This guide covers how to build, test, and submit changes.
+
+By participating you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md). For security
+issues, **do not open a public issue** — follow the [Security Policy](SECURITY.md).
+
+## Build & test
+
+Requires the **.NET 8 SDK**.
+
+```bash
+dotnet restore
+dotnet build TesseraSolution.sln -c Release
+dotnet test  TesseraSolution.sln -c Release
+```
+
+All tests must pass. Live on-chain integration tests are `[SkippableFact]`-gated on environment
+variables and **skip by default** — they only run when you point them at a real (or local) chain:
+
+- **EVM** — see [`chains/evm/README.md`](chains/evm/README.md) → *Local smoke tests*: a local Hardhat
+  node (`scripts/deploy-local.js` + `.env.local.example`) plus the `TESSERA_EVM_*` vars. The
+  `evm-smoke` CI job runs this on every push.
+- **Cardano** — `TESSERA_CARDANO_BLOCKFROST_KEY` + `TESSERA_CARDANO_SKEY` against preprod
+  (`TESSERA_CARDANO_MODE` = `validator` | `metadata`).
+- **Solana** — `TESSERA_SOLANA_*` against devnet.
+
+## On-chain contracts (optional)
+
+Only needed if you change the contracts under `chains/`. Each has its own toolchain and CI job:
+
+| Chain | Dir | Toolchain |
+|---|---|---|
+| EVM | `chains/evm` | Node + Hardhat (`npm ci && npx hardhat test`) |
+| Cardano | `chains/cardano/contracts/identity-registry` | Aiken (`aiken check && aiken build`) |
+| Solana | `chains/solana` | Anchor (`anchor build && anchor test`) |
+| Stellar | `chains/stellar` | Rust + Soroban (`cargo build --target wasm32v1-none`) |
+
+Checked-in artifacts (EVM `abi/*.json`, Cardano `plutus.json`) must stay in sync with the sources —
+CI fails on drift. The C# adapter selectors/addresses are asserted against these artifacts.
+
+## Architecture rules
+
+Read [`docs/architecture.md`](docs/architecture.md) first. Two hard rules:
+
+1. **Layering, dependencies inward**: generic core → replaceable plugins → reference examples. A
+   lower layer never depends on a higher one.
+2. **No vendor / product / use-case names in the generic core.** Domain-specific types live in
+   their plugin (e.g. `btc_*` in `Tessera.Sources.Bitcoin`), never in `Tessera.Attestations`/`Core`.
+
+New behavior needs tests. Match the surrounding code's style, naming, and comment density.
+
+## Commits & pull requests
+
+- **Conventional Commits**: `type(scope): summary` — e.g. `feat(bitcoin): …`, `fix(cardano): …`,
+  `docs: …`, `ci(evm): …`, `test(cardano): …`, `security: …`.
+- Update **[CHANGELOG.md](CHANGELOG.md)** under `## [Unreleased]` for any user-visible change.
+- Keep PRs focused; ensure `dotnet build` + `dotnet test` are green and the
+  [PR checklist](.github/PULL_REQUEST_TEMPLATE.md) is satisfied.
+- Releases are cut by pushing a `vX.Y.Z` tag, which publishes to nuget.org via Trusted Publishing.
+
+Open an issue first for large or breaking changes so we can agree on the approach.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+Tessera is identity- and cryptography-adjacent infrastructure, so security reports are taken
+seriously. Thank you for helping keep it and its users safe.
+
+## Supported versions
+
+| Version | Supported |
+|---|---|
+| 3.3.x (latest) | ✅ Security fixes |
+| < 3.3 | ❌ Please upgrade |
+
+Fixes land on the latest release line. Packages are published on nuget.org under the
+`Sagynbaev.Tessera*` prefix via Trusted Publishing (OIDC) — no long-lived API key is stored.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security vulnerability.**
+
+Report it privately via GitHub's **[Private vulnerability reporting](https://github.com/asagynbaev/Tessera/security/advisories/new)**
+(repo → **Security** → **Report a vulnerability**). If that is unavailable, contact the maintainer
+[@asagynbaev](https://github.com/asagynbaev) and ask for a private channel before sharing details.
+
+When reporting, please include:
+
+- affected package(s) and version(s) (e.g. `Sagynbaev.Tessera.Cryptography 3.3.0`);
+- a description of the issue and its impact;
+- a minimal reproduction or proof of concept, if possible.
+
+You can expect an initial acknowledgement within a few days. Coordinated disclosure is preferred:
+we will work with you on a fix and a release before any public write-up.
+
+## Known limitations (please read before relying on Tessera for high-assurance use)
+
+The cryptographic core (`Tessera.Cryptography`: from-scratch secp256k1, Pedersen commitments, and
+Bulletproofs) is **not constant-time and has not had an external cryptographic audit**. In
+particular, `Point.ScalarMul` is a branch-on-bit double-and-add (leaks the scalar to timing/SPA), and
+the claim-canonicalization wire format is length-prefixed but not type-tagged. **Do not use it to
+protect funds or high-value secrets until that audit is complete.**
+
+The full threat model, what is in/out of scope, the deterministic test vectors, and the deferred
+items are documented in **[docs/security-audit-readiness.md](docs/security-audit-readiness.md)** —
+the dossier an external auditor should start from. On-chain contract notes (e.g. the EVM `registerDid`
+controller-signature ABI change in v3.2.0) are tracked there and in the per-chain READMEs.


### PR DESCRIPTION
Complete the GitHub community standards checklist:
- CODE_OF_CONDUCT.md (Contributor Covenant 2.1)
- .github/PULL_REQUEST_TEMPLATE.md
- .github/ISSUE_TEMPLATE/{bug_report,feature_request,config}.yml
- Track CONTRIBUTING.md and SECURITY.md (were untracked)

Issue/PR templates are tailored to the project: per-chain areas, Sagynbaev.Tessera* package versions, and security reports routed to private vulnerability reporting instead of public issues.