### PR TITLE
Fix/security audit findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,13 @@ the `Sagynbaev.Tessera.Sdk` package); namespaces remain `Tessera.*`.
 | `Tessera.Sources.XRoad` | Layer-2 plugin: X-Road government registry → residency / property / encumbrance. |
 | `Tessera.Sources.Bitcoin` | Layer-2 plugin: proven control of Bitcoin addresses (BIP-137 signed challenge) → `btc_control` (address count only) + Pedersen-committed `btc_balance` / `btc_hodl_age`, each bound to a point-in-time chain snapshot (height/hash/time). Esplora (mempool.space / blockstream.info) provider. |
 
-> **Audit status:** the current release is **3.3.1**, built on the v3.2.0
-> security-hardening baseline (authenticated holder presentations, fail-closed revocation,
-> address-bound wallet binding, authenticated on-chain anchors — see [Security](#security)). `Tessera.Cryptography` remains a
-> from-scratch, **not constant-time** implementation pending external review; constant-time
-> `Point.ScalarMul` is deferred to that audit. Threat model and known limitations:
+> **Audit status:** built on the v3.2.0 security-hardening baseline (authenticated holder
+> presentations, fail-closed revocation, address-bound wallet binding, authenticated on-chain
+> anchors — see [Security](#security)). A subsequent multi-round hardening pass (**no Critical
+> findings**) made `Tessera.Cryptography` **constant-time** (limb-based arithmetic + a branchless
+> scalar multiplication, cross-checked against BouncyCastle), rejected non-canonical encodings, and
+> closed a set of verification / DID / source-plugin findings. It is still from-scratch managed code,
+> so an external crypto audit remains recommended. Threat model and known limitations:
 > [docs/security-audit-readiness.md](docs/security-audit-readiness.md).
 
 ## Repository layout
@@ -326,12 +328,22 @@ guarantees that matter at the trust boundary:
   the current epoch (it no longer silently skips when `ExpectedAnchorRoot` is supplied). A
   presentation freshness window (`MaxPresentationAge` / `MaxClockSkew`, both authenticated via
   the signed `CreatedAt`) bounds replay.
-- **Address-bound wallet binding.** Binding a wallet to a DID proves the bound address is
-  controlled by the wallet key via `IWalletControlVerifier` (the default covers Solana
-  base58(pubkey) and fails closed on chains it does not understand). `BuildWalletChallenge` binds
-  the wallet pubkey, binding nonces are single-use through an `INonceStore`, and
-  `DidService.GetActiveAsync` enforces revocation on resolve. Pepper providers reject all-zero /
+- **Address-bound, controller-authenticated wallet binding.** Binding a wallet to a DID proves the
+  bound address is controlled by the wallet key via `IWalletControlVerifier` (the default covers
+  Solana base58(pubkey) and fails closed on chains it does not understand). `BuildWalletChallenge`
+  binds the wallet pubkey, and binding nonces are single-use through an `INonceStore`. The
+  authenticated `BindWalletAsync` overload additionally requires a DID-**controller** signature over
+  `BuildWalletBindAuthChallenge`, so a wallet owner cannot attach their wallet to another principal's
+  DID. `DidService.GetActiveAsync` enforces revocation on resolve; pepper providers reject all-zero /
   low-entropy peppers.
+- **Constant-time, malleability-resistant primitives.** `Tessera.Cryptography` secp256k1 is
+  constant-time (fixed 4×64-bit limb arithmetic; a fixed-iteration, branchless `Point.ScalarMul`
+  over complete add/double formulas), so the secret scalar does not leak through timing. Point and
+  proof-scalar deserialization rejects non-canonical encodings (`x ≥ p`, `s ≥ n`) rather than
+  reducing them, closing byte-malleability of commitments/proofs. Both are cross-checked against an
+  independent BouncyCastle oracle. The issuer registry refuses to overwrite an existing issuer's
+  public key, and attestation verification supports an expiry cap (`MaxAttestationAge` /
+  `RequireExpiry`).
 - **Source ↔ DID binding.** Sumsub KYC requires the applicant `externalUserId` to equal the
   subject DID; X-Road uses server-asserted identifiers verified against the request. Both clients
   require HTTPS.
@@ -350,9 +362,10 @@ guarantees that matter at the trust boundary:
   sealed-bid auction enforces both bounds; the confidential transfer checks Pedersen balance
   conservation (`amount + change == sender balance`) in addition to the range proofs.
 
-Caveats: `Tessera.Cryptography` is still **not constant-time** — constant-time `Point.ScalarMul`
-and a type-tagged claim-canonicalization wire format are deferred to the planned external
-cryptography audit (claim canonicalization is already culture-invariant). The Anchor (Solana),
+Caveats: `Tessera.Cryptography` is now **constant-time** and rejects non-canonical encodings, but it
+is still from-scratch managed code — an external cryptography audit remains recommended, and two
+BREAKING wire-format hardening items (length-prefixed Fiat–Shamir transcript labels; RFC-6962 Merkle
+odd-node handling) plus a type-tagged claim-canonicalization format are deferred. The Anchor (Solana),
 Aiken (Cardano) and Solidity (EVM) contract changes above are source-level: they require the
 respective toolchain build (`anchor build` / `aiken build` + regenerated `plutus.json` / Hardhat
 compile) and redeploy to take effect on a live network. See
@@ -364,8 +377,9 @@ Planned, not yet shipped:
 
 - **Cardano mainnet** — the preprod path is live today (see the [Chains](#chains) table);
   mainnet is the next step.
-- **External security audit of `Tessera.Cryptography`** — the audit dossier is already public
-  in [docs/security-audit-readiness.md](docs/security-audit-readiness.md).
+- **External security audit of `Tessera.Cryptography`** — now constant-time and BouncyCastle
+  cross-checked, but still self-implemented; the audit dossier is already public in
+  [docs/security-audit-readiness.md](docs/security-audit-readiness.md).
 - **Native Midnight integration** — a zkSNARK stack with selective disclosure on Midnight.
   Does not exist today.
 

--- a/chains/evm/abi/PermissionedToken.abi.json
+++ b/chains/evm/abi/PermissionedToken.abi.json
@@ -211,6 +211,54 @@
     "inputs": [
       {
         "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "subtractedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "addedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
         "name": "to",
         "type": "address"
       },

--- a/chains/evm/contracts/Allowlist.sol
+++ b/chains/evm/contracts/Allowlist.sol
@@ -64,8 +64,15 @@ contract Allowlist {
     function transferOwnership(address newOwner) external {
         if (msg.sender != owner) revert NotAuthorized();
         if (newOwner == address(0)) revert ZeroAddress();
-        emit OwnershipTransferred(owner, newOwner);
+        address previous = owner;
+        emit OwnershipTransferred(previous, newOwner);
+        // Revoke the outgoing owner's agent rights so a handover doesn't silently retain them.
+        if (agents[previous]) {
+            agents[previous] = false;
+            emit AgentSet(previous, false);
+        }
         owner = newOwner;
         agents[newOwner] = true;
+        emit AgentSet(newOwner, true);
     }
 }

--- a/chains/evm/contracts/PermissionedToken.sol
+++ b/chains/evm/contracts/PermissionedToken.sol
@@ -68,6 +68,24 @@ contract PermissionedToken {
         return true;
     }
 
+    /// @notice Atomically raise a spender's allowance, avoiding the approve() front-running race
+    ///         (set-to-N-then-set-to-M lets a watching spender drain N before M lands).
+    function increaseAllowance(address spender, uint256 addedValue) external returns (bool) {
+        uint256 updated = allowance[msg.sender][spender] + addedValue; // 0.8 checked add
+        allowance[msg.sender][spender] = updated;
+        emit Approval(msg.sender, spender, updated);
+        return true;
+    }
+
+    /// @notice Atomically lower a spender's allowance, clamped at zero.
+    function decreaseAllowance(address spender, uint256 subtractedValue) external returns (bool) {
+        uint256 current = allowance[msg.sender][spender];
+        uint256 updated = subtractedValue >= current ? 0 : current - subtractedValue;
+        allowance[msg.sender][spender] = updated;
+        emit Approval(msg.sender, spender, updated);
+        return true;
+    }
+
     function transferFrom(address from, address to, uint256 amount) external returns (bool) {
         uint256 current = allowance[from][msg.sender];
         if (current < amount) revert InsufficientAllowance();

--- a/chains/evm/test/allowlist.test.js
+++ b/chains/evm/test/allowlist.test.js
@@ -67,6 +67,22 @@ describe("Allowlist", function () {
     expect(await allowlist.isAllowed(user.address)).to.equal(true);
   });
 
+  it("transferOwnership revokes the outgoing owner's agent rights and grants the new owner", async function () {
+    await expect(allowlist.transferOwnership(agent.address))
+      .to.emit(allowlist, "OwnershipTransferred")
+      .withArgs(owner.address, agent.address);
+
+    // Old owner is no longer an agent; new owner is.
+    expect(await allowlist.agents(owner.address)).to.equal(false);
+    expect(await allowlist.agents(agent.address)).to.equal(true);
+
+    await expect(
+      allowlist.connect(owner).addToAllowlist(user.address)
+    ).to.be.revertedWithCustomError(allowlist, "NotAuthorized");
+    await allowlist.connect(agent).addToAllowlist(user.address);
+    expect(await allowlist.isAllowed(user.address)).to.equal(true);
+  });
+
   it("removeFromAllowlist is idempotent (remove when never added)", async function () {
     await allowlist.removeFromAllowlist(user.address); // no revert
     expect(await allowlist.isAllowed(user.address)).to.equal(false);

--- a/docs/security-audit-readiness.md
+++ b/docs/security-audit-readiness.md
@@ -36,13 +36,64 @@ proof verification on-chain. Auditors should confirm no code path writes anythin
 | 3 | Replay across verifiers / sessions / chains / time | Challenge binds `{holder, verifier, session_nonce, as_of_epoch, chain, created_at, leaf_hashes}`; freshness window (`MaxPresentationAge`/`MaxClockSkew`) always enforced | `Verifier.VerifyPresentationAsync` steps 1–3, 6 |
 | 4 | Stale presentation after revocation | Revocation is FAIL-CLOSED: with a chain anchor reachable, an epoch older than the chain's current epoch is always rejected; `RequireCurrentRevocationEpoch` demands a reachable anchor and EXACT epoch match | `Verifier.VerifyPresentationAsync` step 5; `AnchorState.RevocationEpoch` |
 | 5 | Issuer key compromise | Per-issuer `active` flag + `deactivateIssuer` (EVM) / `deactivate_issuer` (Solana) + short attestation expiries | issuer registry read/write |
-| 6 | DID front-running / wallet- and address-spoofing | EVM `registerDid` requires a controller ECDSA signature bound to `(didHash, root, chainid, contract)`; wallet binding proves the address is controlled by the wallet key (`IWalletControlVerifier`) and consumes a single-use nonce (`INonceStore`) | `EvmRegistrationSigner`, `IdentityRegistry.registerDid`, `DefaultWalletControlVerifier`, `DidService.BindWalletAsync` |
+| 6 | DID front-running / address-spoofing / binding a wallet to a victim DID | EVM `registerDid` requires a controller ECDSA signature bound to `(didHash, root, chainid, contract)`; wallet binding proves the address is controlled by the wallet key (`IWalletControlVerifier`) and consumes a single-use nonce (`INonceStore`); the authenticated `BindWalletAsync` overload additionally requires a DID-controller signature, so a wallet cannot be attached to another principal's DID | `EvmRegistrationSigner`, `IdentityRegistry.registerDid`, `DefaultWalletControlVerifier`, `DidService.BindWalletAsync` |
 | 7 | Source ↔ subject impersonation | Sumsub requires applicant `externalUserId == subject DID`; X-Road binds the server-asserted national id from the response back to the request; both clients require https | `SumsubAttestationSource`, `XRoadAttestationSource` |
 | 8 | Allowlist tamper | Restriction contract is agent/owner-gated; gateway only reflects decisions | `Allowlist.sol`, `EvmAllowlistGateway` |
 | 9 | EVM write double-submission | Writes are single-shot; only reads are retried; the adapter checks `receipt.Status` on every write | `EvmChainAnchor.SendAsync`, `EvmRetry` |
 | 10 | Range/predicate soundness | Bulletproofs range proof; **see Known limitations** | `RangeProof.Verify`, `PolicyEvaluation` |
+| 11 | Side-channel: secret scalar leaked via timing | secp256k1 field/scalar/point arithmetic is constant-time (limb-based; fixed-iteration branchless `ScalarMul` over complete formulas); cross-checked against BouncyCastle | `FieldElement`, `Scalar`, `Point.ScalarMul`, `OracleCrossCheckTests` |
+| 12 | Encoding malleability of commitments/proofs | non-canonical encodings (`x ≥ p`, `s ≥ n`) are rejected on deserialization, not reduced | `FieldElement.FromCanonicalBytes`, `Scalar.FromCanonicalBytes`, `Point.Decode` |
+| 13 | Issuer trust-root substitution | the registry refuses to overwrite an existing issuer's public key via upsert | `EfCoreIssuerRegistry.RegisterAsync` |
 
 ## Addressed
+
+> **Latest security-hardening pass.** A multi-round review (cryptography, on-chain, external-service,
+> and IDOR/race methodology) closed the items below. **No Critical findings were identified in any
+> round.** The fixes land across a coordinated set of branches merging into the next release —
+> `fix/constant-time-secp256k1` (constant-time crypto + canonical encodings),
+> `fix/security-audit-findings` (verification, DID/registry, source-plugin, chain-adapter fixes), and
+> `chore/remove-legacy-crypto-duplicate` (legacy-duplicate removal).
+>
+> - **Constant-time secp256k1 (was Known limitation #1).** `FieldElement` / `Scalar` / `Point` are
+>   reimplemented over fixed 4×64-bit limbs (no `BigInteger` in the hot path): pseudo-Mersenne
+>   reduction mod p, Barrett reduction mod n, fixed-exponent inversion, and a fixed 256-iteration
+>   double-and-add-ALWAYS `ScalarMul` with a branchless point-select over complete add/double
+>   formulas — the loop length, per-bit work, and memory access no longer depend on the secret
+>   scalar. Correctness is pinned by a NEW independent **BouncyCastle cross-check oracle**
+>   (`OracleCrossCheckTests`), since self-consistent round-trip tests cannot catch a reduction bug.
+>   *Residual:* still self-implemented managed code (JIT-level constant-timeness is not formally
+>   guaranteed) and ~4–8× slower than the prior version — an external crypto audit is still
+>   recommended; the legacy `Tessera.Crypto` duplicate stack that shipped a second, variable-time
+>   copy of the secp256k1 arithmetic in the meta-package was removed.
+> - **Canonical point/scalar encodings.** `Point.Decode` and the Bulletproofs scalar readers now
+>   REJECT non-canonical encodings (`x ≥ p`, `s ≥ n`) via `FromCanonicalBytes` instead of reducing
+>   them — closing byte-malleability of serialized commitments/proofs. The reducing `FromBytes` is
+>   kept only where reduction is correct (Fiat–Shamir challenge squeeze, hash-to-curve).
+> - **Controller-authenticated wallet binding (BOLA).** `DidService.BindWalletAsync` gained an
+>   authenticated overload requiring a controller signature over `BuildWalletBindAuthChallenge`
+>   (binds did + document version + wallet identity); the original overload is now documented
+>   trusted-caller-only, so a wallet owner can no longer attach their wallet to another principal's
+>   DID. The binding write also bumps the document `Version` (previously it broke the EF store's
+>   optimistic-concurrency token and the resurrect-revoked guard).
+> - **Issuer trust-root protection.** `EfCoreIssuerRegistry.RegisterAsync` refuses to overwrite an
+>   already-registered issuer's public key via the upsert (key rotation must be explicit), closing a
+>   trust-anchor substitution / issuer-impersonation path.
+> - **Verification hardening.** Optional `MaxAttestationAge` / `RequireExpiry` cap non-expiring
+>   credentials; the attestation algorithm tag is matched case-insensitively (empty tag rejected); a
+>   cached `ExpectedAnchorRoot` is cross-checked against the live anchor (`anchor_root_stale`) so a
+>   root rotation that removed an attestation cannot be replayed against a stale cache;
+>   `PresentationVerifier` docs corrected to crypto-content-only (revocation/freshness live in the
+>   SDK `Verifier`).
+> - **Decoder & input hardening.** Length guards on the hand-rolled length-prefixed decoders
+>   (`CredentialProof`, Borsh reader, the example transfer codec); channel handles are NFKC-normalised
+>   + length-capped (homoglyph collisions); claim-policy matching reads values with the same
+>   invariant formatter the issuer signs with; `Base58.Decode` is length-capped with a zero-byte fix.
+> - **Source-plugin & chain-adapter hardening.** Esplora `BaseUrl` is validated (absolute http(s) +
+>   host) to block scheme-based SSRF; the Bitcoin control challenge rejects line breaks in
+>   subject/audience (canonical-string ambiguity); Cardano metadata-mode reads select the HIGHEST
+>   authenticated revocation epoch (no lower-epoch republish can mask a bump); the in-memory nonce
+>   store keeps an eviction margin past expiry; the reference `PermissionedToken` gains
+>   `increase`/`decreaseAllowance` (ERC-20 approve race).
 
 - **Predicate ↔ attestation binding (was the primary gap).** `CredentialProof.CommitValue` +
   `ProveBoundMinimum`/`ProveBoundRange` + `VerifyBound` bind a range proof to the attestation's
@@ -106,13 +157,18 @@ proof verification on-chain. Auditors should confirm no code path writes anythin
 
 ## Known limitations (do not ship to high-assurance use without addressing)
 
-1. **`Tessera.Cryptography` is not constant-time / not formally reviewed.** Self-implemented
-   secp256k1 + Bulletproofs. No claim of side-channel resistance; needs an external crypto audit
-   before protecting funds or high-value secrets. Concretely DEFERRED to that audit:
-   `Point.ScalarMul` is still a branch-on-bit double-and-add (NOT constant-time — leaks the scalar
-   to SPA/timing), and the claim-canonicalization wire format is length-prefixed but not yet
-   type-tagged. Claim canonicalization is now culture-invariant. The predicate binding and two-sided
-   range proofs in §"Addressed" rely on the `Point`/`Scalar` arithmetic being correct.
+1. **`Tessera.Cryptography` is now constant-time but still self-implemented / not formally reviewed.**
+   `Point.ScalarMul` and the field/scalar arithmetic are now constant-time (limb-based, branchless
+   ladder — see §"Addressed"), and non-canonical encodings are rejected. It remains from-scratch
+   MANAGED code, so an external cryptography audit is still recommended before protecting funds or
+   high-value secrets, and JIT-level constant-timeness is not formally guaranteed. Two
+   soundness/format items stay DEFERRED because their fixes are BREAKING wire-format changes (see
+   §"Deferred"): the Fiat–Shamir `Transcript` does not length-prefix its labels (collision is not
+   reachable with the current fixed label set, but it relies on caller discipline), and the Merkle
+   tree duplicates the unpaired node (CVE-2012-2459 class, currently mitigated by leaf-hash
+   rebinding). The claim-canonicalization wire format is culture-invariant but not yet type-tagged.
+   The predicate binding and two-sided range proofs in §"Addressed" rely on the `Point`/`Scalar`
+   arithmetic being correct — now cross-checked against BouncyCastle (`OracleCrossCheckTests`).
 2. **Solana/Cardano contract hardening is source-level; those live networks need a build + redeploy.**
    The admin/governance gates and authentication described in §"Addressed" land in the contract
    sources but only take effect once each toolchain compiles and the artifact is redeployed: the
@@ -145,9 +201,12 @@ proof verification on-chain. Auditors should confirm no code path writes anythin
 
 Auditors can reproduce these:
 
-- `Tessera.Cryptography.Tests` — primitive correctness (33+ tests), incl. `AuditVectorsTests`:
-  Pedersen determinism, additive homomorphism KAT, generator stability, range-proof verify,
-  and tamper-evidence (flipping a proof/commitment byte fails verification).
+- `Tessera.Cryptography.Tests` — primitive correctness (51 tests), incl. `AuditVectorsTests`
+  (Pedersen determinism, additive-homomorphism KAT, generator stability, range-proof verify,
+  tamper-evidence) and `OracleCrossCheckTests` — an INDEPENDENT BouncyCastle cross-check of the
+  field / scalar / point arithmetic (mul, add, sub, inverse, sqrt, `k·G`, `k·H`, point addition, the
+  curve constants) on edge + pseudo-random inputs, plus canonical-encoding rejection. This external
+  oracle catches self-consistent reduction bugs that round-trip self-tests cannot.
 - `Tessera.Chains.Evm.Tests/AbiContractParityTests` — every C# function selector is asserted
   equal to `keccak256(canonicalSignature)[:4]` **and** to the compiled contract ABI
   (`chains/evm/abi/*.json`), so the adapter cannot silently drift from the contract.
@@ -176,9 +235,16 @@ Auditors can reproduce these:
 
 ## Deferred (write-down, to finish later)
 
-- Engage an external cryptography auditor for `Tessera.Cryptography`; in scope for that audit:
-  constant-time `Point.ScalarMul` (SPA/timing hardening) and a type-tagged claim-canonicalization
-  wire format (limitation 1).
+- Engage an external cryptography auditor for `Tessera.Cryptography` (now constant-time, but
+  self-implemented). DEFERRED here because the fixes are BREAKING wire-format changes: length-prefix
+  the Fiat–Shamir `Transcript` labels; adopt RFC-6962-style Merkle odd-node handling instead of
+  duplication (CVE-2012-2459 class); and a type-tagged claim-canonicalization wire format
+  (limitation 1).
+- Solana issuer-registry hardening (needs `anchor build`): a `set_issuer_active` / reactivation
+  instruction (today `deactivate_issuer` is irreversible because `register_issuer` uses `init`), and
+  a zero / on-curve guard on the recorded `signing_key`.
+- An authenticated controller-key-rotation path in `DidService` — today a compromised or lost
+  controller key has no recovery ceremony beyond revoking with that same key.
 - Build + redeploy the hardened Solana/Cardano contracts so the new gates take effect on live
   networks: `anchor build` (Solana `RegistryConfig` / `deactivate_issuer`), `aiken build` +
   regenerated `plutus.json` (Aiken `issuer_registry` admin gate) (limitation 2). EVM is compiled,

--- a/examples/PrivacyApps/ConfidentialTransfer.cs
+++ b/examples/PrivacyApps/ConfidentialTransfer.cs
@@ -148,6 +148,8 @@ namespace Tessera.Examples.PrivacyApps
         private static byte[] ReadField(BinaryReader r)
         {
             int len = r.ReadInt32();
+            if (len < 0 || len > r.BaseStream.Length - r.BaseStream.Position)
+                throw new FormatException($"TransferBundle: invalid field length {len}.");
             return r.ReadBytes(len);
         }
     }

--- a/src/Tessera.Attestations.Tests/AttestationTests.cs
+++ b/src/Tessera.Attestations.Tests/AttestationTests.cs
@@ -147,6 +147,58 @@ public class AttestationTests
         Assert.Equal("expired", result.Reason);
     }
 
+    private static (AttestationIssuer issuer, AttestationVerifier verifier) BuildPairWithOptions(
+        TimeSpan? maxAge = null, bool requireExpiry = false)
+    {
+        var priv = RandomNumberGenerator.GetBytes(32);
+        var pub = SHA256.HashData(priv);
+        var issuerDid = new DidId("did:tessera:" + Convert.ToHexString(SHA256.HashData(pub)));
+        var registry = new InMemoryIssuerRegistry();
+        registry.Register(new IssuerRecord
+        {
+            Did = issuerDid,
+            PublicKey = pub,
+            Algorithm = "ed25519",
+            SchemaUri = "https://schemas.tessera/attestation/v1",
+            Active = true,
+        });
+        return (
+            new AttestationIssuer(issuerDid, new StubSigner(priv, pub)),
+            new AttestationVerifier(registry, new StubVerifier(priv, pub),
+                maxAttestationAge: maxAge, requireExpiry: requireExpiry));
+    }
+
+    [Fact]
+    public async Task Verify_TooOld_WhenMaxAgeExceeded()
+    {
+        var (issuer, verifier) = BuildPairWithOptions(maxAge: TimeSpan.FromMilliseconds(1));
+        var att = issuer.Issue("phone_verified", new DidId("did:tessera:s"), new AttestationPayload { Method = "twilio" });
+        await Task.Delay(50);
+        var result = await verifier.VerifyAsync(att);
+        Assert.False(result.Valid);
+        Assert.Equal("too_old", result.Reason);
+    }
+
+    [Fact]
+    public async Task Verify_MissingExpiry_WhenRequired_Fails()
+    {
+        var (issuer, verifier) = BuildPairWithOptions(requireExpiry: true);
+        var att = issuer.Issue("human_verified", new DidId("did:tessera:s"), new AttestationPayload { Method = "civic" });
+        var result = await verifier.VerifyAsync(att);
+        Assert.False(result.Valid);
+        Assert.Equal("missing_expiry", result.Reason);
+    }
+
+    [Fact]
+    public async Task Verify_WithExpiry_SatisfiesRequireExpiry()
+    {
+        var (issuer, verifier) = BuildPairWithOptions(requireExpiry: true);
+        var att = issuer.Issue("human_verified", new DidId("did:tessera:s"),
+            new AttestationPayload { Method = "civic" }, validity: TimeSpan.FromHours(1));
+        var result = await verifier.VerifyAsync(att);
+        Assert.True(result.Valid, result.Reason);
+    }
+
     [Fact]
     public void MerkleTree_RoundTripInclusion()
     {

--- a/src/Tessera.Attestations.Tests/AttestationTests.cs
+++ b/src/Tessera.Attestations.Tests/AttestationTests.cs
@@ -147,6 +147,17 @@ public class AttestationTests
         Assert.Equal("expired", result.Reason);
     }
 
+    [Fact]
+    public async Task Verify_AlgorithmTag_IsCaseInsensitive()
+    {
+        // Issuer registered as "ED25519"; signature tag is the canonical lowercase "ed25519". The tag
+        // is metadata (not part of the signed canonical input), so a case difference must NOT reject.
+        var (_, issuer, verifier, _) = BuildPair(algorithm: "ED25519");
+        var att = issuer.Issue("human_verified", new DidId("did:tessera:s"), new AttestationPayload { Method = "civic" });
+        var result = await verifier.VerifyAsync(att);
+        Assert.True(result.Valid, result.Reason);
+    }
+
     private static (AttestationIssuer issuer, AttestationVerifier verifier) BuildPairWithOptions(
         TimeSpan? maxAge = null, bool requireExpiry = false)
     {

--- a/src/Tessera.Attestations/AttestationCanonical.cs
+++ b/src/Tessera.Attestations/AttestationCanonical.cs
@@ -76,7 +76,7 @@ public static class AttestationCanonical
     /// string-valued claims for cross-implementation determinism; a future major version may switch to
     /// a type-tagged, length-framed claim encoding (a breaking wire change).
     /// </remarks>
-    private static string FormatClaimValueInvariant(object? value) => value switch
+    public static string FormatClaimValueInvariant(object? value) => value switch
     {
         null => "",
         string s => s,

--- a/src/Tessera.Attestations/AttestationVerifier.cs
+++ b/src/Tessera.Attestations/AttestationVerifier.cs
@@ -61,6 +61,8 @@ public sealed class AttestationVerifier
         if (string.IsNullOrEmpty(a.Schema)) return VerificationResult.Fail("missing_schema");
         if (a.Signature is null || a.Signature.Value.Length == 0)
             return VerificationResult.Fail("missing_signature");
+        if (string.IsNullOrWhiteSpace(a.Signature.Algorithm))
+            return VerificationResult.Fail("missing_algorithm");
 
         var now = _clock.GetUtcNow();
         if (_requireExpiry && a.ExpiresAt is null)
@@ -76,7 +78,9 @@ public sealed class AttestationVerifier
         var issuer = await _issuers.ResolveAsync(a.Issuer, ct).ConfigureAwait(false);
         if (issuer is null) return VerificationResult.Fail("unknown_issuer");
         if (!issuer.Active) return VerificationResult.Fail("issuer_inactive");
-        if (!string.Equals(issuer.Algorithm, a.Signature.Algorithm, StringComparison.Ordinal))
+        // Case-insensitive: the algorithm tag is metadata (NOT part of the signed canonical input),
+        // so "Ed25519"/"ed25519" must not silently reject an otherwise-valid issuer's attestations.
+        if (!string.Equals(issuer.Algorithm, a.Signature.Algorithm, StringComparison.OrdinalIgnoreCase))
             return VerificationResult.Fail("algorithm_mismatch");
 
         var input = AttestationCanonical.BuildSigningInput(a);

--- a/src/Tessera.Attestations/AttestationVerifier.cs
+++ b/src/Tessera.Attestations/AttestationVerifier.cs
@@ -26,12 +26,31 @@ public sealed class AttestationVerifier
     private readonly IIssuerRegistry _issuers;
     private readonly ISignatureVerifier _verifier;
     private readonly TimeProvider _clock;
+    private readonly TimeSpan? _maxAge;
+    private readonly bool _requireExpiry;
 
-    public AttestationVerifier(IIssuerRegistry issuers, ISignatureVerifier verifier, TimeProvider? clock = null)
+    /// <param name="maxAttestationAge">
+    /// When set, an attestation is rejected (<c>too_old</c>) once <c>now − IssuedAt</c> exceeds it.
+    /// Caps the lifetime of credentials whose issuer set no <c>ExpiresAt</c>. Null = no age cap.
+    /// </param>
+    /// <param name="requireExpiry">
+    /// When true, an attestation without an <c>ExpiresAt</c> is rejected (<c>missing_expiry</c>) so a
+    /// sensitive credential cannot be valid forever. Default false (backward-compatible).
+    /// </param>
+    public AttestationVerifier(
+        IIssuerRegistry issuers,
+        ISignatureVerifier verifier,
+        TimeProvider? clock = null,
+        TimeSpan? maxAttestationAge = null,
+        bool requireExpiry = false)
     {
         _issuers = issuers ?? throw new ArgumentNullException(nameof(issuers));
         _verifier = verifier ?? throw new ArgumentNullException(nameof(verifier));
         _clock = clock ?? TimeProvider.System;
+        if (maxAttestationAge is { } age && age <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(maxAttestationAge), "Max attestation age must be positive.");
+        _maxAge = maxAttestationAge;
+        _requireExpiry = requireExpiry;
     }
 
     public async Task<VerificationResult> VerifyAsync(Attestation a, CancellationToken ct = default)
@@ -44,8 +63,12 @@ public sealed class AttestationVerifier
             return VerificationResult.Fail("missing_signature");
 
         var now = _clock.GetUtcNow();
+        if (_requireExpiry && a.ExpiresAt is null)
+            return VerificationResult.Fail("missing_expiry");
         if (a.ExpiresAt is { } exp && exp < now)
             return VerificationResult.Fail("expired");
+        if (_maxAge is { } maxAge && now - a.IssuedAt > maxAge)
+            return VerificationResult.Fail("too_old");
 
         if (a.IssuedAt > now.AddMinutes(5))
             return VerificationResult.Fail("issued_in_future");

--- a/src/Tessera.Attestations/CredentialProof.cs
+++ b/src/Tessera.Attestations/CredentialProof.cs
@@ -277,14 +277,20 @@ namespace Tessera.Attestations
             var threshold = r.ReadInt64();
             var upper = r.ReadInt64();
             int cLen = r.ReadInt32();
+            if (cLen < 0 || cLen > ms.Length - ms.Position)
+                throw new FormatException("CredentialBundle: invalid commitment length.");
             var commitment = r.ReadBytes(cLen);
             int pLen = r.ReadInt32();
+            if (pLen < 0 || pLen > ms.Length - ms.Position)
+                throw new FormatException("CredentialBundle: invalid range-proof length.");
             var proof = r.ReadBytes(pLen);
 
             byte[]? upperProof = null;
             if (ms.Position < ms.Length)
             {
                 int uLen = r.ReadInt32();
+                if (uLen < 0 || uLen > ms.Length - ms.Position)
+                    throw new FormatException("CredentialBundle: invalid upper-proof length.");
                 if (uLen > 0) upperProof = r.ReadBytes(uLen);
             }
 

--- a/src/Tessera.Attestations/PresentationVerifier.cs
+++ b/src/Tessera.Attestations/PresentationVerifier.cs
@@ -3,11 +3,20 @@ namespace Tessera.Attestations;
 using Tessera.Core;
 
 /// <summary>
-/// End-to-end verification of a holder's presentation: the holder signature on the binding must
-/// verify against the key the holder DID derives from, each disclosed attestation must verify
-/// against its issuer, its Merkle inclusion path must hash to the expected root, and (caller-supplied)
-/// the root must match what is anchored on-chain for the holder DID at <c>AsOfRevocationEpoch</c>.
+/// CRYPTOGRAPHIC verification of a holder's presentation ONLY: the holder signature on the binding
+/// verifies against the key the holder DID derives from, each disclosed attestation verifies against
+/// its issuer, and each Merkle inclusion path hashes to the <paramref name="expectedAnchorRoot"/>
+/// supplied by the caller.
 /// </summary>
+/// <remarks>
+/// This class does NOT enforce revocation freshness, presentation freshness, verifier/audience
+/// binding, or that <c>expectedAnchorRoot</c> is the CURRENT on-chain root for the holder DID — it
+/// trusts the root it is handed. Those checks are the caller's responsibility; use
+/// <see cref="Tessera.Sdk.Verifier"/> for full end-to-end verification (it resolves the live anchor,
+/// rejects stale <c>AsOfRevocationEpoch</c>, and enforces the freshness window before delegating the
+/// cryptographic content here). Calling this class directly with a cached or holder-supplied root
+/// skips revocation and accepts a revoked or stale credential.
+/// </remarks>
 public sealed class PresentationVerifier
 {
     private readonly AttestationVerifier _attestationVerifier;

--- a/src/Tessera.Chains.Cardano/CardanoChainAnchor.cs
+++ b/src/Tessera.Chains.Cardano/CardanoChainAnchor.cs
@@ -201,14 +201,27 @@ public sealed class CardanoChainAnchor : IChainAnchor, IDisposable
         // the controller before trusting it, and skip (rather than fail) on anything unauthenticated
         // so a poisoned tx cannot suppress the controller's own newer state. GetMetadataTxsAsync
         // returns newest-first; take the first entry that authenticates for this DID.
+        // Select the authenticated candidate with the HIGHEST epoch — not merely the newest tx. In
+        // metadata mode nothing on-chain enforces monotonicity, so a lower-epoch republish (or a
+        // concurrent root refresh that preserved the old epoch) must not be able to mask a higher-epoch
+        // revocation bump.
+        MetadataTx? best = null;
+        byte[] bestRoot = Array.Empty<byte>();
+        ulong bestEpoch = 0;
         foreach (var tx in txs)
         {
             if (!TryReadDidMatch(tx, didHex, didHash, out var root, out var epoch)) continue;
             if (!IsFromController(tx)) continue;
-            var updatedAt = await ResolveBlockTimeAsync(tx.TxHash, ct).ConfigureAwait(false);
-            return AnchorStateMapper.ToAnchorState(did, root, epoch, updatedAt);
+            if (best is null || epoch > bestEpoch)
+            {
+                best = tx;
+                bestRoot = root;
+                bestEpoch = epoch;
+            }
         }
-        return null;
+        if (best is null) return null;
+        var updatedAt = await ResolveBlockTimeAsync(best.TxHash, ct).ConfigureAwait(false);
+        return AnchorStateMapper.ToAnchorState(did, bestRoot, bestEpoch, updatedAt);
     }
 
     /// <summary>

--- a/src/Tessera.Chains.Cardano/CardanoChainAnchor.cs
+++ b/src/Tessera.Chains.Cardano/CardanoChainAnchor.cs
@@ -160,6 +160,11 @@ public sealed class CardanoChainAnchor : IChainAnchor, IDisposable
         var utxo = await FindAnchorUtxoAsync(didHash, ct).ConfigureAwait(false);
         if (utxo?.InlineDatumCbor is null) return null;
         var datum = DatumCodec.DecodeAnchorDatum(utxo.InlineDatumCbor);
+        // Bind the datum to the queried DID. The asset name (policyId‖didHash) selected this UTxO, but
+        // a misconfigured or swappable validator/minting policy could attach a datum for a DIFFERENT
+        // did_hash. Fail closed (treat as no anchor) unless the datum's own DidHash is the one queried.
+        if (!datum.DidHash.AsSpan().SequenceEqual(didHash))
+            return null;
         var updatedAt = await ResolveBlockTimeAsync(utxo.TxHash, ct).ConfigureAwait(false);
         return AnchorStateMapper.ToAnchorState(did, datum, updatedAt);
     }

--- a/src/Tessera.Chains.Solana/Internal/AnchorBorsh.cs
+++ b/src/Tessera.Chains.Solana/Internal/AnchorBorsh.cs
@@ -118,6 +118,8 @@ internal ref struct AnchorBorshReader
 
     public byte[] ReadFixedBytes(int length)
     {
+        if (length < 0 || length > _buf.Length)
+            throw new FormatException($"Borsh: cannot read {length} bytes ({_buf.Length} remaining).");
         var result = _buf[..length].ToArray();
         _buf = _buf[length..];
         return result;
@@ -127,7 +129,11 @@ internal ref struct AnchorBorshReader
 
     public string ReadString()
     {
+        // The u32 length is attacker-controlled (raw on-chain account bytes); reject anything that
+        // overruns the buffer before slicing. The (int) cast also turns lengths >= 2^31 negative.
         var len = (int)ReadU32();
+        if (len < 0 || len > _buf.Length)
+            throw new FormatException($"Borsh: string length {len} exceeds {_buf.Length} remaining bytes.");
         var bytes = _buf[..len];
         var s = Encoding.UTF8.GetString(bytes);
         _buf = _buf[len..];

--- a/src/Tessera.Channels.Tests/ChannelNormalizerTests.cs
+++ b/src/Tessera.Channels.Tests/ChannelNormalizerTests.cs
@@ -1,0 +1,39 @@
+using Tessera.Channels;
+
+namespace Tessera.Channels.Tests;
+
+/// <summary>
+/// Covers the homoglyph/compatibility-collision fix (M-4): the normaliser applies NFKC so two
+/// visually-identical handles cannot derive different commitments, and the length cap (Low).
+/// </summary>
+public class ChannelNormalizerTests
+{
+    private static readonly DefaultChannelNormalizer Normalizer = new();
+
+    [Fact]
+    public void Email_NfkcFoldsFullwidthToAscii()
+    {
+        // "ＦＯＯ@bar.com" with FULLWIDTH F/O/O (U+FF26, U+FF2F) must canonicalise identically to ASCII.
+        var fullwidth = Normalizer.Normalize(ChannelTypes.Email, "ＦＯＯ@bar.com");
+        var ascii = Normalizer.Normalize(ChannelTypes.Email, "FOO@bar.com");
+
+        Assert.Equal("foo@bar.com", fullwidth);
+        Assert.Equal(ascii, fullwidth);
+    }
+
+    [Fact]
+    public void Telegram_NfkcFoldsCompatibilityForms()
+    {
+        // "＠Alice" (fullwidth @) → strip @ → fold → lowercase.
+        var a = Normalizer.Normalize(ChannelTypes.Telegram, "＠Alice");
+        var b = Normalizer.Normalize(ChannelTypes.Telegram, "@alice");
+        Assert.Equal(b, a);
+    }
+
+    [Fact]
+    public void Normalize_RejectsOverlongHandle()
+    {
+        var huge = new string('a', 300) + "@bar.com";
+        Assert.Throws<ArgumentException>(() => Normalizer.Normalize(ChannelTypes.Email, huge));
+    }
+}

--- a/src/Tessera.Channels/IChannelNormalizer.cs
+++ b/src/Tessera.Channels/IChannelNormalizer.cs
@@ -29,12 +29,20 @@ public interface IChannelNormalizer
 /// </summary>
 public sealed class DefaultChannelNormalizer : IChannelNormalizer
 {
+    /// <summary>Upper bound on handle length: bounds the work and the phone normaliser's stack buffer.</summary>
+    private const int MaxHandleLength = 256;
+
     public string Normalize(string channelType, string handle)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(handle);
         ArgumentException.ThrowIfNullOrEmpty(channelType);
+        if (handle.Length > MaxHandleLength)
+            throw new ArgumentException($"Handle exceeds {MaxHandleLength} characters.", nameof(handle));
 
-        var trimmed = handle.Trim();
+        // NFKC folds Unicode compatibility/confusable forms so two visually-identical handles cannot
+        // derive different commitments (nor a look-alike dodge an existing binding). This participates
+        // in the on-disk format, but only changes commitments for non-NFKC (i.e. non-ASCII) handles.
+        var trimmed = handle.Normalize(System.Text.NormalizationForm.FormKC).Trim();
 
         return channelType switch
         {

--- a/src/Tessera.Core/Base58.cs
+++ b/src/Tessera.Core/Base58.cs
@@ -30,9 +30,17 @@ public static class Base58
         return sb.ToString();
     }
 
+    /// <summary>
+    /// Maximum accepted input length. Legitimate Tessera values (32-byte hashes, public keys) encode
+    /// to ~50 chars; the cap bounds the O(n²) BigInteger decode against an unbounded-input DoS.
+    /// </summary>
+    private const int MaxEncodedLength = 512;
+
     public static byte[] Decode(ReadOnlySpan<char> s)
     {
         if (s.IsEmpty) return Array.Empty<byte>();
+        if (s.Length > MaxEncodedLength)
+            throw new FormatException($"Base58 input too long ({s.Length} > {MaxEncodedLength}).");
 
         int leadingZeros = 0;
         while (leadingZeros < s.Length && s[leadingZeros] == Alphabet[0]) leadingZeros++;
@@ -46,7 +54,9 @@ public static class Base58
             bi = bi * fiftyEight + idx;
         }
 
-        var bytes = bi.ToByteArray(isUnsigned: true, isBigEndian: true);
+        // A zero value (all-'1' input) must contribute no value bytes: ToByteArray would emit a
+        // spurious 0x00 that double-counts with the leading-zero prefix added below.
+        var bytes = bi.IsZero ? Array.Empty<byte>() : bi.ToByteArray(isUnsigned: true, isBigEndian: true);
         if (leadingZeros == 0) return bytes;
 
         var result = new byte[leadingZeros + bytes.Length];

--- a/src/Tessera.Did.Tests/DidServiceTests.cs
+++ b/src/Tessera.Did.Tests/DidServiceTests.cs
@@ -240,6 +240,40 @@ public class DidServiceTests
     }
 
     [Fact]
+    public async Task BindWallet_Authenticated_RequiresControllerSignature()
+    {
+        // BOLA fix: the authenticated overload must reject a missing/invalid controller signature, so a
+        // wallet owner cannot attach their wallet to a DID without the DID controller's consent — even
+        // though the wallet signature itself is valid.
+        var kr = new TestKeyring();
+        var (didPub, didPriv) = kr.NewKey();
+        var (walletPub, walletPriv) = kr.NewKey();
+        var svc = new DidService(new InMemoryDidStore(), kr.Verifier);
+        var doc = await svc.CreateAsync(didPub);
+
+        var unsigned = new WalletBindingRequest
+        {
+            Chain = "solana",
+            Address = Base58.Encode(walletPub),
+            WalletPublicKey = walletPub,
+            Nonce = RandomNumberGenerator.GetBytes(16),
+            Expiry = DateTimeOffset.UtcNow.AddMinutes(5),
+            Signature = Array.Empty<byte>(),
+        };
+        var request = unsigned with { Signature = kr.Sign(walletPriv, DidService.BuildWalletChallenge(doc.Id, unsigned)) };
+
+        // Wrong controller signature is rejected (valid wallet signature is not enough).
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => svc.BindWalletAsync(doc.Id, request, new byte[32]));
+
+        // Correct controller signature over the canonical wallet-bind-auth challenge is accepted.
+        var controllerSig = kr.Sign(didPriv, DidService.BuildWalletBindAuthChallenge(doc.Id, doc.Version, request));
+        var updated = await svc.BindWalletAsync(doc.Id, request, controllerSig);
+        Assert.Single(updated.Wallets);
+        Assert.Equal(doc.Version + 1, updated.Version);
+    }
+
+    [Fact]
     public async Task Revoke_MarksDocumentRevoked()
     {
         var kr = new TestKeyring();

--- a/src/Tessera.Did/DidService.cs
+++ b/src/Tessera.Did/DidService.cs
@@ -113,10 +113,17 @@ public sealed class DidService
     }
 
     /// <summary>
-    /// Bind a wallet to a DID by verifying that the wallet itself signed a challenge
-    /// containing <c>{did, chain, address, nonce, expiry}</c>. The binding is verifiable
-    /// without trusting any issuer.
+    /// Bind a wallet to a DID by verifying that the wallet itself signed a challenge containing
+    /// <c>{did, chain, address, nonce, expiry}</c> and that the wallet key provably controls the address.
     /// </summary>
+    /// <remarks>
+    /// <b>Trusted-caller-only overload.</b> It proves the WALLET consents to the binding, but NOT that
+    /// the DID controller authorized it — so any wallet owner could otherwise attach their own wallet to
+    /// another principal's DID document. Untrusted/remote callers MUST use
+    /// <see cref="BindWalletAsync(DidId, WalletBindingRequest, ReadOnlyMemory{byte}, CancellationToken)"/>,
+    /// which additionally requires a controller signature. Use this overload only when the caller has
+    /// already authenticated the DID controller out-of-band.
+    /// </remarks>
     public async Task<DidDocument> BindWalletAsync(
         DidId did,
         WalletBindingRequest request,
@@ -124,7 +131,41 @@ public sealed class DidService
     {
         ArgumentNullException.ThrowIfNull(request);
         var doc = await GetRequiredAsync(did, ct).ConfigureAwait(false);
+        return await BindWalletCoreAsync(doc, did, request, ct).ConfigureAwait(false);
+    }
 
+    /// <summary>
+    /// Authenticated overload of <see cref="BindWalletAsync(DidId, WalletBindingRequest, CancellationToken)"/>.
+    /// Requires <paramref name="controllerSignature"/> over the canonical "wallet-bind-auth" challenge
+    /// (see <see cref="BuildWalletBindAuthChallenge"/>) verified against the DID's controller key, so a
+    /// wallet can only be attached with the DID owner's consent. The wallet signature proves the wallet
+    /// agrees; the controller signature proves the DID controller agrees. Mirrors the channel-bind pattern.
+    /// </summary>
+    public async Task<DidDocument> BindWalletAsync(
+        DidId did,
+        WalletBindingRequest request,
+        ReadOnlyMemory<byte> controllerSignature,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var doc = await GetRequiredAsync(did, ct).ConfigureAwait(false);
+        if (doc.Revoked)
+            throw new InvalidOperationException($"DID is revoked: {did}.");
+
+        var controllerKey = ResolveControllerKey(doc);
+        var challenge = BuildWalletBindAuthChallenge(did, doc.Version, request);
+        if (!_verifier.Verify(controllerKey, challenge, controllerSignature.Span))
+            throw new InvalidOperationException("Controller signature did not verify against the wallet-bind challenge.");
+
+        return await BindWalletCoreAsync(doc, did, request, ct).ConfigureAwait(false);
+    }
+
+    private async Task<DidDocument> BindWalletCoreAsync(
+        DidDocument doc,
+        DidId did,
+        WalletBindingRequest request,
+        CancellationToken ct)
+    {
         if (doc.Revoked)
             throw new InvalidOperationException($"DID is revoked: {did}.");
 
@@ -206,6 +247,27 @@ public sealed class DidService
         w.Write(request.Nonce.Length);
         w.Write(request.Nonce);
         w.Write(request.Expiry.ToUnixTimeSeconds());
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Canonical challenge the DID CONTROLLER signs to authorize a wallet binding — distinct from the
+    /// wallet-signed <see cref="BuildWalletChallenge"/>. Binds the DID, the current document version
+    /// (so the authorization can't be replayed onto a later document state), and the wallet identity
+    /// (chain, address, length-prefixed wallet key).
+    /// </summary>
+    public static byte[] BuildWalletBindAuthChallenge(DidId did, long version, WalletBindingRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        using var ms = new MemoryStream();
+        using var w = new BinaryWriter(ms);
+        w.Write("Tessera/v1/wallet-bind-auth");
+        w.Write(did.Value);
+        w.Write(version);
+        w.Write(request.Chain);
+        w.Write(request.Address);
+        w.Write(request.WalletPublicKey.Length);
+        w.Write(request.WalletPublicKey);
         return ms.ToArray();
     }
 

--- a/src/Tessera.Did/DidService.cs
+++ b/src/Tessera.Did/DidService.cs
@@ -169,6 +169,10 @@ public sealed class DidService
                 .Where(w => !(w.Chain == request.Chain && w.Address == request.Address))
                 .Append(binding)
                 .ToArray(),
+            // Bump the version like every other mutation: the EF store pins its optimistic-concurrency
+            // token to Version-1, so skipping the bump both breaks binding on the relational store and
+            // would leave the resurrect-revoked guard ineffective for this write path.
+            Version = doc.Version + 1,
             UpdatedAt = _clock.GetUtcNow(),
         };
         await _store.SaveAsync(updated, ct).ConfigureAwait(false);

--- a/src/Tessera.Did/INonceStore.cs
+++ b/src/Tessera.Did/INonceStore.cs
@@ -48,12 +48,16 @@ public sealed class InMemoryNonceStore : INonceStore
         return Task.FromResult(fresh);
     }
 
+    // Retain entries past their stored expiry so a replay arriving in a post-expiry clock-skew grace
+    // window is still caught: eviction must not coincide with the still-presentable boundary.
+    private static readonly TimeSpan EvictionMargin = TimeSpan.FromMinutes(5);
+
     private void EvictExpired()
     {
-        var now = _clock.GetUtcNow();
+        var threshold = _clock.GetUtcNow() - EvictionMargin;
         foreach (var kvp in _seen)
         {
-            if (kvp.Value <= now)
+            if (kvp.Value <= threshold)
                 _seen.TryRemove(kvp.Key, out _);
         }
     }

--- a/src/Tessera.EntityFrameworkCore.Tests/EfCoreIssuerRegistryTests.cs
+++ b/src/Tessera.EntityFrameworkCore.Tests/EfCoreIssuerRegistryTests.cs
@@ -75,6 +75,29 @@ public class EfCoreIssuerRegistryTests
     }
 
     [Fact]
+    public async Task Register_TwiceWithDifferentPublicKey_IsRejected()
+    {
+        using var fx = new SqliteFixture();
+        var first = SampleIssuer("did:tessera:trust-root");
+        var keyRotation = first with { PublicKey = RandomNumberGenerator.GetBytes(32) };
+
+        await using (var db = fx.CreateContext())
+            await new EfCoreIssuerRegistry(db).RegisterAsync(first);
+
+        await using (var db = fx.CreateContext())
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => new EfCoreIssuerRegistry(db).RegisterAsync(keyRotation));
+
+        // The original trust-anchor key is unchanged — no silent issuer-key takeover via upsert.
+        await using (var verifyDb = fx.CreateContext())
+        {
+            var loaded = await new EfCoreIssuerRegistry(verifyDb).ResolveAsync(first.Did);
+            Assert.NotNull(loaded);
+            Assert.Equal(first.PublicKey, loaded.PublicKey);
+        }
+    }
+
+    [Fact]
     public async Task Deactivate_RemovesFromResolveResults()
     {
         using var fx = new SqliteFixture();

--- a/src/Tessera.EntityFrameworkCore/EfCoreIssuerRegistry.cs
+++ b/src/Tessera.EntityFrameworkCore/EfCoreIssuerRegistry.cs
@@ -52,6 +52,13 @@ public sealed class EfCoreIssuerRegistry : IIssuerRegistry, IIssuerRegistrar
         }
         else
         {
+            // The issuer registry is the trust root for attestation verification. Refuse to silently
+            // overwrite an already-registered issuer's PUBLIC KEY via this upsert — that would
+            // substitute the trust anchor and impersonate the issuer. Key rotation must be deliberate.
+            if (!existing.PublicKey.AsSpan().SequenceEqual(record.PublicKey))
+                throw new InvalidOperationException(
+                    $"Refusing to overwrite the public key of already-registered issuer '{record.Did.Value}' " +
+                    "via RegisterAsync. Issuer key rotation must be an explicit, authorized operation.");
             DomainMappings.ToEntity(record, now, existing);
         }
 

--- a/src/Tessera.Sdk.Tests/EndToEndFlowTests.cs
+++ b/src/Tessera.Sdk.Tests/EndToEndFlowTests.cs
@@ -270,6 +270,46 @@ public class EndToEndFlowTests
             }));
     }
 
+    [Fact]
+    public async Task Verifier_StaleCachedRoot_VsLiveAnchor_Fails()
+    {
+        // TOCTOU: a cached ExpectedAnchorRoot must not be trusted when a live anchor disagrees — a
+        // root rotation that removed an attestation does NOT bump the revocation epoch, so the stale
+        // root would otherwise still verify a presentation of the since-removed attestation.
+        var (holder, holderPriv, chain, issuer, registry, verifier) = await BuildPair();
+        holder.AcceptAttestation(issuer.Issue("phone_verified", holder.Did, new AttestationPayload { Method = "x" }));
+        await holder.AnchorRootAsync();
+        var staleRoot = holder.CurrentRoot; // R1, cached by the verifier
+
+        var verifierDid = new DidId("did:tessera:app");
+        var presentation = holder.BuildSignedPresentation(
+            verifier: verifierDid,
+            attestationTypes: new[] { "phone_verified" },
+            sessionNonce: RandomBytes(16),
+            asOfRevocationEpoch: 0,
+            chain: "test",
+            signChallenge: ch => Ed25519.Sign(holderPriv, ch.Span));
+
+        // Anchored root rotates to R2 (!= R1) WITHOUT bumping the epoch.
+        await chain.AnchorRootAsync(holder.Did, new byte[32]);
+
+        var zkpVerifier = new Verifier(new VerifierOptions
+        {
+            IssuerRegistry = registry,
+            SignatureVerifier = verifier,
+            ChainAnchor = chain,
+        });
+
+        var result = await zkpVerifier.VerifyPresentationAsync(presentation, new VerificationPolicy
+        {
+            ExpectedVerifier = verifierDid,
+            ExpectedAnchorRoot = staleRoot, // cached R1, but the live anchor now holds R2
+        });
+
+        Assert.False(result.Valid);
+        Assert.Equal("anchor_root_stale", result.Reason);
+    }
+
     // ── helpers ──────────────────────────────────────────────────────────
 
     private record FlowFixture(

--- a/src/Tessera.Sdk/VerificationPolicyRules.cs
+++ b/src/Tessera.Sdk/VerificationPolicyRules.cs
@@ -202,8 +202,11 @@ internal static class PolicyEvaluation
             if (req.AllowedValues is null || req.AllowedValues.Count == 0)
                 return true; // presence of the claim is sufficient
 
-            var asText = value?.ToString();
-            if (asText is not null && req.AllowedValues.Any(v => string.Equals(v, asText, StringComparison.OrdinalIgnoreCase)))
+            // Read the claim value with the SAME invariant formatter the issuer signed it with
+            // (AttestationCanonical), so the policy gates on exactly the canonical bytes and cannot be
+            // satisfied by a value the issuer never signed under a different locale/type rendering.
+            var asText = AttestationCanonical.FormatClaimValueInvariant(value);
+            if (req.AllowedValues.Any(v => string.Equals(v, asText, StringComparison.OrdinalIgnoreCase)))
                 return true;
         }
         return false;

--- a/src/Tessera.Sdk/Verifier.cs
+++ b/src/Tessera.Sdk/Verifier.cs
@@ -25,7 +25,9 @@ public sealed class Verifier
         ArgumentNullException.ThrowIfNull(options);
         _options = options;
         _clock = options.Clock ?? TimeProvider.System;
-        _attVerifier = new AttestationVerifier(options.IssuerRegistry, options.SignatureVerifier, options.Clock);
+        _attVerifier = new AttestationVerifier(
+            options.IssuerRegistry, options.SignatureVerifier, options.Clock,
+            options.MaxAttestationAge, options.RequireExpiry);
         _presVerifier = new PresentationVerifier(_attVerifier, options.SignatureVerifier);
     }
 

--- a/src/Tessera.Sdk/Verifier.cs
+++ b/src/Tessera.Sdk/Verifier.cs
@@ -87,7 +87,15 @@ public sealed class Verifier
 
         byte[] expectedRoot;
         if (policy.ExpectedAnchorRoot is { } caller)
+        {
+            // A caller-supplied (cached/offline) root is honoured, but when a live anchor is ALSO
+            // reachable it must match it. A root rotation that removed an attestation does NOT bump
+            // the revocation epoch, so a stale cached root would otherwise still verify a presentation
+            // of a since-removed attestation (use-after-removal / TOCTOU).
+            if (state is not null && !caller.AsSpan().SequenceEqual(state.AttestationRoot))
+                return new VerificationResult { Valid = false, Reason = "anchor_root_stale" };
             expectedRoot = caller;
+        }
         else if (state is not null)
             expectedRoot = state.AttestationRoot;
         else if (_options.ChainAnchor is null)

--- a/src/Tessera.Sdk/VerifierOptions.cs
+++ b/src/Tessera.Sdk/VerifierOptions.cs
@@ -23,4 +23,16 @@ public sealed record VerifierOptions
     /// <see cref="TimeProvider.System"/>. Inject a fake provider in tests.
     /// </summary>
     public TimeProvider? Clock { get; init; }
+
+    /// <summary>
+    /// When set, an attestation is rejected (<c>too_old</c>) once <c>now − IssuedAt</c> exceeds this,
+    /// capping the lifetime of credentials whose issuer set no <c>ExpiresAt</c>. Null = no age cap.
+    /// </summary>
+    public TimeSpan? MaxAttestationAge { get; init; }
+
+    /// <summary>
+    /// When true, an attestation lacking an <c>ExpiresAt</c> is rejected (<c>missing_expiry</c>), so a
+    /// sensitive credential cannot be valid forever. Default false (backward-compatible).
+    /// </summary>
+    public bool RequireExpiry { get; init; }
 }

--- a/src/Tessera.Sources.Bitcoin.Tests/BitcoinChallengeTests.cs
+++ b/src/Tessera.Sources.Bitcoin.Tests/BitcoinChallengeTests.cs
@@ -30,6 +30,20 @@ public class BitcoinChallengeTests
     }
 
     [Fact]
+    public void CanonicalString_RejectsLineBreakInFields()
+    {
+        // A subject DID or audience carrying a line break would make the line-joined canonical bytes
+        // ambiguous — two different (sub, aud) interpretations could share one signature. Reject it.
+        var evilAud = BitcoinChallenge.Create(new DidId("did:tessera:x"), "good", TimeSpan.FromMinutes(5))
+            with { Audience = "good\naud=evil" };
+        Assert.Throws<InvalidOperationException>(() => evilAud.ToCanonicalString());
+
+        var evilSub = BitcoinChallenge.Create(new DidId("did:tessera:x"), "good", TimeSpan.FromMinutes(5))
+            with { Subject = new DidId("did:tessera:x\naud=evil") };
+        Assert.Throws<InvalidOperationException>(() => evilSub.ToCanonicalString());
+    }
+
+    [Fact]
     public void Create_ProducesFreshNonce_OfRequestedSize_AndWindow()
     {
         var clock = new FakeClock(DateTimeOffset.FromUnixTimeSeconds(1_700_000_000));

--- a/src/Tessera.Sources.Bitcoin/BitcoinChallenge.cs
+++ b/src/Tessera.Sources.Bitcoin/BitcoinChallenge.cs
@@ -79,6 +79,10 @@ public sealed record BitcoinChallenge
     {
         if (Nonce is null || Nonce.Length < 16)
             throw new InvalidOperationException("Challenge nonce must be at least 16 bytes.");
+        // The canonical string is line-joined, so a field containing a line separator would make the
+        // signed bytes ambiguous (two different (sub, aud) interpretations could share one signature).
+        if (HasLineBreak(Subject.Value) || HasLineBreak(Audience))
+            throw new InvalidOperationException("Challenge subject/audience must not contain line breaks.");
 
         var nonceHex = Convert.ToHexString(Nonce).ToLowerInvariant();
         var sb = new StringBuilder();
@@ -93,4 +97,6 @@ public sealed record BitcoinChallenge
 
     /// <summary>The canonical string encoded as UTF-8 bytes.</summary>
     public byte[] ToCanonicalBytes() => Encoding.UTF8.GetBytes(ToCanonicalString());
+
+    private static bool HasLineBreak(string s) => s.Contains('\n') || s.Contains('\r');
 }

--- a/src/Tessera.Sources.Bitcoin/EsploraBitcoinProvider.cs
+++ b/src/Tessera.Sources.Bitcoin/EsploraBitcoinProvider.cs
@@ -32,6 +32,15 @@ public sealed class EsploraBitcoinProvider : IBitcoinProvider, IDisposable
         var baseUrl = string.IsNullOrWhiteSpace(options.BaseUrl)
             ? BitcoinNetworkInfo.DefaultEsploraBaseUrl(options.Network)
             : options.BaseUrl!.TrimEnd('/');
+        // Validate the base URL like the Sumsub/XRoad clients do: an absolute http(s) URL with a host.
+        // Blocks scheme-based SSRF (file://, gopher://, …) and malformed values. NOTE: BaseUrl must be
+        // operator-controlled config, never request/tenant-derived — this provider's reads become
+        // attestation facts (balance / hodl-age), so a hostile endpoint could fabricate them.
+        if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var parsedBase)
+            || (parsedBase.Scheme != Uri.UriSchemeHttps && parsedBase.Scheme != Uri.UriSchemeHttp)
+            || string.IsNullOrWhiteSpace(parsedBase.Host))
+            throw new ArgumentException(
+                $"Esplora BaseUrl must be an absolute http(s) URL with a host; got '{baseUrl}'.", nameof(options));
 
         _ownsHttp = http is null;
         _http = http ?? new HttpClient();


### PR DESCRIPTION
<!--
Thanks for contributing to Tessera! Please fill out the sections below.
See CONTRIBUTING.md for build/test instructions and the architecture rules.
-->

## Summary

<!-- What does this PR change, and why? Link any related issue: Closes #123 -->

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Docs / chore / CI only

## Affected area

<!-- e.g. Tessera.Cryptography, Tessera.Attestations, chains/evm, chains/cardano, docs -->

## Checklist

- [x] `dotnet build TesseraSolution.sln -c Release` is green.
- [x] `dotnet test TesseraSolution.sln -c Release` is green.
- [ ] New or changed behavior is covered by tests.
- [x] Commits follow **Conventional Commits** (`type(scope): summary`).
- [x] **[CHANGELOG.md](../CHANGELOG.md)** updated under `## [Unreleased]` for any user-visible change.
- [ ] No vendor / product / use-case names leaked into the generic core (see [architecture rules](../CONTRIBUTING.md#architecture-rules)).
- [ ] If contracts under `chains/` changed: checked-in artifacts (`abi/*.json`, `plutus.json`) are regenerated and in sync.
- [x] This PR does **not** contain a security vulnerability fix that should be reported privately first (see [SECURITY.md](../SECURITY.md)).

## Notes for reviewers

<!-- Anything reviewers should pay special attention to: trade-offs, follow-ups, out-of-scope items. -->
