### PR TITLE
fix(evm): override adm-zip to 0.6.0 and move EVM CI to Node 22

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm ci
@@ -101,7 +101,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Set up .NET SDK
         uses: actions/setup-dotnet@v4

--- a/chains/evm/package-lock.json
+++ b/chains/evm/package-lock.json
@@ -1160,13 +1160,13 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
-      "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=0.3.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/aes-js": {

--- a/chains/evm/package.json
+++ b/chains/evm/package.json
@@ -17,6 +17,7 @@
     "hardhat": "^2.29.0"
   },
   "overrides": {
+    "adm-zip": "^0.6.0",
     "cookie": "^0.7.0",
     "serialize-javascript": "^7.0.5",
     "tmp": "^0.2.6",


### PR DESCRIPTION
## Summary
- The open Dependabot alert on `adm-zip` (<0.6.0, a crafted ZIP triggers a 4GB allocation) comes from `hardhat@2.x`, which pins `adm-zip ^0.4.16`. Dependabot's only proposed fix is the hardhat 2→3 major bump — the same one rolled back in #34, which is why its new PR #36 fails (`hardhat 3` needs Node ≥22.13 and the CI job runs Node 20, plus the v4 plugin line and an ESM config migration).
- Fix the alert in place instead: force `adm-zip ^0.6.0` through the existing `overrides` block and regenerate the lockfile. Once this lands, the alert resolves and PR #36 should auto-close.
- Also bump `setup-node` from 20 to 22 in the `evm-contract`/`evm-smoke` jobs: Node 20 is deprecated on Actions runners and hardhat 2.29 supports 22.

## Test plan
- [x] `npx hardhat clean && npm test` in `chains/evm`: clean compile, 29/29 passing locally with adm-zip 0.6.0
- [ ] CI green on this PR